### PR TITLE
Add support for N64 controller accessories

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,7 @@ target_sources(
     src/host/n64.c
     src/target/gc_controller.c
     src/target/n64_controller.c
+    src/target/n64_rumble_pak.c
 )
 
 # Specify the include paths

--- a/examples/pico-sdk/joybus-shell/main.c
+++ b/examples/pico-sdk/joybus-shell/main.c
@@ -427,8 +427,8 @@ static void cmd_n64_accessory_write(int argc, char **argv)
     return;
 
   // Parse the block of data bytes as hex or decimal
-  uint8_t data[JOYBUS_ACCESSORY_DATA_SIZE];
-  for (int i = 0; i < JOYBUS_ACCESSORY_DATA_SIZE; i++) {
+  uint8_t data[JOYBUS_ACCESSORY_BLOCK_SIZE];
+  for (int i = 0; i < JOYBUS_ACCESSORY_BLOCK_SIZE; i++) {
     if (parse_byte(argv[i + 2], &data[i]) < 0)
       return;
   }

--- a/examples/pico-sdk/n64-target/main.c
+++ b/examples/pico-sdk/n64-target/main.c
@@ -24,7 +24,7 @@ int main()
   joybus_enable(bus);
 
   // Initialize a N64 controller target as a standard controller
-  joybus_n64_controller_init(&n64_controller, JOYBUS_ID_N64_CONTROLLER);
+  joybus_n64_controller_init(&n64_controller);
 
   // Register the target on the bus
   joybus_target_register(bus, JOYBUS_TARGET(&n64_controller));

--- a/include/joybus/checksum.h
+++ b/include/joybus/checksum.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
 
@@ -38,3 +39,11 @@ uint8_t joybus_crc8(const uint8_t *data, size_t size);
  * @return     5-bit checksum in the low bits of the returned byte
  */
 uint8_t joybus_address_checksum(uint16_t addr);
+
+/**
+ * Validate the 5-bit address checksum for an N64 data transfer command.
+ *
+ * @param addr 16-bit address with checksum in the low 5 bits
+ * @return     true if the checksum is valid, false if not
+ */
+bool joybus_address_checksum_valid(uint16_t addr);

--- a/include/joybus/commands.h
+++ b/include/joybus/commands.h
@@ -88,6 +88,7 @@
 #define JOYBUS_ID_N64_ACCESSORY_PRESENT   0x01    ///< Accessory present
 #define JOYBUS_ID_N64_ACCESSORY_ABSENT    0x02    ///< Accessory absent
 #define JOYBUS_ID_N64_ACCESSORY_CHANGED   0x03    ///< Accessory changed
+#define JOYBUS_ID_N64_CHECKSUM_ERROR      0x04    ///< Transfer checksum error
 
 // N64 identify status values (VRU)
 #define JOYBUS_ID_N64_VRU_UNINITIALIZED   0x00    ///< VRU is uninitialized

--- a/include/joybus/commands.h
+++ b/include/joybus/commands.h
@@ -119,8 +119,8 @@
 /// Device type for a WaveBird receiver
 #define JOYBUS_WAVEBIRD_RECEIVER          (JOYBUS_ID_GCN_DEVICE | JOYBUS_ID_GCN_WIRELESS | JOYBUS_ID_GCN_NO_MOTOR)
 
-/// Size of a Joybus N64 accessory read/write payload
-#define JOYBUS_ACCESSORY_DATA_SIZE        32
+/// Size of a Joybus N64 accessory read/write block
+#define JOYBUS_ACCESSORY_BLOCK_SIZE       32
 
 /**
  * Get the controller type from an "identify" buffer

--- a/include/joybus/errors.h
+++ b/include/joybus/errors.h
@@ -4,15 +4,15 @@
  * Joybus error codes.
  */
 enum joybus_error {
-  /** Bus not enabled */
+  /// Bus not enabled
   JOYBUS_ERR_DISABLED = 1,
 
-  /** Bus is busy with another operation */
+  /// Bus is busy with another operation
   JOYBUS_ERR_BUSY,
 
-  /** Transfer timed out */
+  /// Transfer timed out
   JOYBUS_ERR_TIMEOUT,
 
-  /** Command not supported by Joybus target */
+  /// Command not supported by Joybus target
   JOYBUS_ERR_NOT_SUPPORTED,
 };

--- a/include/joybus/gamecube.h
+++ b/include/joybus/gamecube.h
@@ -30,31 +30,31 @@
  * GameCube controller input state.
  */
 struct joybus_gc_controller_input {
-  /** Button state */
+  /// Button state
   uint16_t buttons;
 
-  /** Main stick x-axis position */
+  /// Main stick x-axis position
   uint8_t stick_x;
 
-  /** Main stick y-axis position */
+  /// Main stick y-axis position
   uint8_t stick_y;
 
-  /** C-stick x-axis position */
+  /// C-stick x-axis position
   uint8_t substick_x;
 
-  /** C-stick y-axis position */
+  /// C-stick y-axis position
   uint8_t substick_y;
 
-  /** Left analog trigger position */
+  /// Left analog trigger position
   uint8_t trigger_left;
 
-  /** Right analog trigger position */
+  /// Right analog trigger position
   uint8_t trigger_right;
 
-  /** Analog A button value */
+  /// Analog A button value
   uint8_t analog_a;
 
-  /** Analog B button value */
+  /// Analog B button value
   uint8_t analog_b;
 } __attribute__((packed));
 
@@ -62,19 +62,19 @@ struct joybus_gc_controller_input {
  * Analog modes for packing GameCube controller input state.
  */
 enum joybus_gcn_analog_mode {
-  /** Substick X/Y full precision, triggers and analog A/B truncated to 4 bits */
+  /// Substick X/Y full precision, triggers and analog A/B truncated to 4 bits
   JOYBUS_GCN_ANALOG_MODE_0,
 
-  /** Triggers full precision, substick X/Y and analog A/B truncated to 4 bits */
+  /// Triggers full precision, substick X/Y and analog A/B truncated to 4 bits
   JOYBUS_GCN_ANALOG_MODE_1,
 
-  /** Analog A/B full precision, substick X/Y and triggers truncated to 4 bits */
+  /// Analog A/B full precision, substick X/Y and triggers truncated to 4 bits
   JOYBUS_GCN_ANALOG_MODE_2,
 
-  /** Substick X/Y and triggers full precision, analog A/B omitted */
+  /// Substick X/Y and triggers full precision, analog A/B omitted
   JOYBUS_GCN_ANALOG_MODE_3,
 
-  /** Substick X/Y and analog A/B full precision, triggers omitted */
+  /// Substick X/Y and analog A/B full precision, triggers omitted
   JOYBUS_GCN_ANALOG_MODE_4,
 };
 
@@ -82,12 +82,12 @@ enum joybus_gcn_analog_mode {
  * GameCube controller motor states.
  */
 enum joybus_gcn_motor_state {
-  /** Stop the rumble motor */
+  /// Stop the rumble motor
   JOYBUS_GCN_MOTOR_STOP,
 
-  /** Start the rumble motor */
+  /// Start the rumble motor
   JOYBUS_GCN_MOTOR_RUMBLE,
 
-  /** Stop the rumble motor immediately */
+  /// Stop the rumble motor immediately
   JOYBUS_GCN_MOTOR_STOP_HARD,
 };

--- a/include/joybus/host/n64.h
+++ b/include/joybus/host/n64.h
@@ -14,25 +14,25 @@
  * N64 controller accessory types.
  */
 enum joybus_n64_accessory_type {
-  /** No accessory connected */
+  /// No accessory connected
   JOYBUS_N64_ACCESSORY_NONE = 0,
 
-  /** Accessory type could not be determined */
+  /// Accessory type could not be determined
   JOYBUS_N64_ACCESSORY_UNKNOWN,
 
-  /** Controller Pak */
+  /// Controller Pak
   JOYBUS_N64_ACCESSORY_CONTROLLER_PAK,
 
-  /** Rumble Pak */
+  /// Rumble Pak
   JOYBUS_N64_ACCESSORY_RUMBLE_PAK,
 
-  /** Transfer Pak */
+  /// Transfer Pak
   JOYBUS_N64_ACCESSORY_TRANSFER_PAK,
 
-  /** Bio Sensor */
+  /// Bio Sensor
   JOYBUS_N64_ACCESSORY_BIO_SENSOR,
 
-  /** Snap Station */
+  /// Snap Station
   JOYBUS_N64_ACCESSORY_SNAP_STATION,
 };
 

--- a/include/joybus/n64.h
+++ b/include/joybus/n64.h
@@ -26,12 +26,12 @@
  * N64 controller input state.
  */
 struct joybus_n64_controller_input {
-  /** Button state */
+  /// Button state
   uint16_t buttons;
 
-  /** Stick x-axis position */
+  /// Stick x-axis position
   uint8_t stick_x;
 
-  /** Stick y-axis position */
+  /// Stick y-axis position
   uint8_t stick_y;
 } __attribute__((packed));

--- a/include/joybus/target.h
+++ b/include/joybus/target.h
@@ -10,9 +10,7 @@
 
 struct joybus_target;
 
-/**
- * Macro to cast a concrete Joybus target instance to a generic Joybus target instance.
- */
+/// Macro to cast a concrete Joybus target instance to a generic Joybus target instance.
 #define JOYBUS_TARGET(target) ((struct joybus_target *)(target))
 
 /**
@@ -24,7 +22,9 @@ struct joybus_target;
  */
 typedef void (*joybus_target_response_cb_t)(const uint8_t *response, uint8_t len, void *user_data);
 
-// API for a Joybus target.
+/**
+ * API for implementing a Joybus target.
+ */
 struct joybus_target_api {
   /**
    * Handle a received command byte.
@@ -41,10 +41,13 @@ struct joybus_target_api {
 };
 
 /**
- * A Joybus target, a device on the Joybus that can respond to commands.
+ * Interface for a Joybus target, a device on the Joybus which responds to commands from a host.
  */
 struct joybus_target {
+  /// API for handling received commands
   const struct joybus_target_api *api;
+
+  /// Whether the target is currently registered on the bus
   bool registered;
 };
 
@@ -62,6 +65,17 @@ static inline int joybus_target_byte_received(struct joybus_target *target, cons
                                               joybus_target_response_cb_t send_response, void *user_data)
 {
   return target->api->byte_received(target, command, byte_idx, send_response, user_data);
+}
+
+/**
+ * Check if a target is currently registered on the bus.
+ *
+ * @param target the target to check
+ * @return true if the target is registered, false otherwise
+ */
+static inline bool joybus_target_is_registered(struct joybus_target *target)
+{
+  return target->registered;
 }
 
 /** @} */

--- a/include/joybus/target/gc_controller.h
+++ b/include/joybus/target/gc_controller.h
@@ -1,6 +1,6 @@
 /**
  * @defgroup joybus_target_gc_controller GameCube Controller Target
- * GameCube controller Joybus target
+ * Joybus target implementation for standard GameCube controllers and WaveBird receivers.
  * @ingroup joybus_target
  * @{
  */
@@ -15,7 +15,7 @@
 
 struct joybus_gc_controller;
 
-/** Macro to cast to a GameCube controller target */
+/// Macro to cast from a generic Joybus target to a GameCube controller target
 #define JOYBUS_GC_CONTROLLER(target) ((struct joybus_gc_controller *)(target))
 
 /**
@@ -37,34 +37,35 @@ typedef void (*joybus_gc_controller_motor_cb_t)(struct joybus_gc_controller *con
  * GameCube controller Joybus target.
  */
 struct joybus_gc_controller {
+  /// Base target interface
   struct joybus_target base;
 
-  /**< Controller ID */
+  /// Controller ID
   uint8_t id[3];
 
-  /** Origin input state */
+  /// Origin input state
   struct joybus_gc_controller_input origin;
 
-  /** Current input state */
+  /// Current input state
   struct joybus_gc_controller_input input;
 
-  /** Packed input state buffer */
+  /// Packed input state buffer
   uint8_t packed_input[8];
 
-  /** Whether the input state is valid */
+  /// Whether the input state is valid
   bool input_valid;
 
-  /** Callback for controller reset events */
+  /// Callback for controller reset events
   joybus_gc_controller_reset_cb_t on_reset;
 
-  /** Callback for controller motor state change events */
+  /// Callback for controller motor state change events
   joybus_gc_controller_motor_cb_t on_motor_state_change;
 };
 
 /**
  * Initialize a GameCube controller.
  *
- * This function sets up the initial state, and registers SI command
+ * This function sets up the initial state, and registers Joybus command
  * handlers for OEM GameCube controller, and WaveBird controller commands.
  *
  * @param controller the controller to initialize

--- a/include/joybus/target/n64_accessory.h
+++ b/include/joybus/target/n64_accessory.h
@@ -1,0 +1,61 @@
+/**
+ * @defgroup joybus_target_n64_accessory N64 Controller Accessory
+ * Base interface for N64 controller accessories (rumble pak, controller pak, etc.)
+ * @ingroup joybus_target_n64_controller
+ * @{
+ */
+
+#pragma once
+
+#include <stdint.h>
+
+#include <joybus/commands.h>
+
+struct joybus_n64_accessory;
+
+/** Macro to cast to an N64 accessory */
+#define JOYBUS_N64_ACCESSORY(acc) ((struct joybus_n64_accessory *)(acc))
+
+/**
+ * N64 accessory backend API.
+ *
+ * All accessory I/O is block-aligned: every read and write covers exactly
+ * JOYBUS_ACCESSORY_BLOCK_SIZE bytes at a block-aligned address.
+ */
+struct joybus_n64_accessory_api {
+  /**
+   * Read a 32-byte block from the accessory.
+   *
+   * Called from interrupt context, on the response critical path. Must
+   * complete quickly (well under the 62.5 us response budget).
+   *
+   * @param accessory the accessory being read from
+   * @param addr      block-aligned address (low 5 bits are zero)
+   * @param buf       destination buffer, exactly 32 bytes
+   */
+  void (*read_block)(struct joybus_n64_accessory *accessory, uint16_t addr, uint8_t buf[JOYBUS_ACCESSORY_BLOCK_SIZE]);
+
+  /**
+   * Write a 32-byte block to the accessory.
+   *
+   * Called from interrupt context, AFTER the CRC response has been sent.
+   * The host is no longer waiting, so this may take longer than the
+   * response budget, but `buf` is borrowed and must not be retained
+   * after this function returns.
+   *
+   * @param accessory the accessory being written to
+   * @param addr      block-aligned address (low 5 bits are zero)
+   * @param buf       source buffer, exactly 32 bytes
+   */
+  void (*write_block)(struct joybus_n64_accessory *accessory, uint16_t addr,
+                      const uint8_t buf[JOYBUS_ACCESSORY_BLOCK_SIZE]);
+};
+
+/**
+ * An N64 controller accessory, such as a rumble pak or controller pak.
+ */
+struct joybus_n64_accessory {
+  const struct joybus_n64_accessory_api *api;
+};
+
+/** @} */

--- a/include/joybus/target/n64_accessory.h
+++ b/include/joybus/target/n64_accessory.h
@@ -13,21 +13,17 @@
 
 struct joybus_n64_accessory;
 
-/** Macro to cast to an N64 accessory */
+/// Macro to cast a concrete N64 accessory instance to a generic N64 accessory instance.
 #define JOYBUS_N64_ACCESSORY(acc) ((struct joybus_n64_accessory *)(acc))
 
 /**
- * N64 accessory backend API.
- *
- * All accessory I/O is block-aligned: every read and write covers exactly
- * JOYBUS_ACCESSORY_BLOCK_SIZE bytes at a block-aligned address.
+ * API for implementing an N64 controller accessory.
  */
 struct joybus_n64_accessory_api {
   /**
    * Read a 32-byte block from the accessory.
    *
-   * Called from interrupt context, on the response critical path. Must
-   * complete quickly (well under the 62.5 us response budget).
+   * Called from interrupt context, on the response critical path.
    *
    * @param accessory the accessory being read from
    * @param addr      block-aligned address (low 5 bits are zero)
@@ -39,9 +35,6 @@ struct joybus_n64_accessory_api {
    * Write a 32-byte block to the accessory.
    *
    * Called from interrupt context, AFTER the CRC response has been sent.
-   * The host is no longer waiting, so this may take longer than the
-   * response budget, but `buf` is borrowed and must not be retained
-   * after this function returns.
    *
    * @param accessory the accessory being written to
    * @param addr      block-aligned address (low 5 bits are zero)
@@ -55,6 +48,7 @@ struct joybus_n64_accessory_api {
  * An N64 controller accessory, such as a rumble pak or controller pak.
  */
 struct joybus_n64_accessory {
+  /// API for handling reads and writes to the accessory
   const struct joybus_n64_accessory_api *api;
 };
 

--- a/include/joybus/target/n64_controller.h
+++ b/include/joybus/target/n64_controller.h
@@ -10,6 +10,7 @@
 #include <joybus/bus.h>
 #include <joybus/n64.h>
 #include <joybus/target.h>
+#include <joybus/target/n64_accessory.h>
 
 struct joybus_n64_controller;
 
@@ -22,13 +23,6 @@ struct joybus_n64_controller;
  * @param controller the controller that was reset
  */
 typedef void (*joybus_n64_controller_reset_cb_t)(struct joybus_n64_controller *controller);
-
-/**
- * N64 controller accessory, such as a rumble pak or memory pak.
- */
-struct joybus_n64_accessory {
-  // TODO
-};
 
 /**
  * N64 controller Joybus target.

--- a/include/joybus/target/n64_controller.h
+++ b/include/joybus/target/n64_controller.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <joybus/bus.h>
 #include <joybus/n64.h>
 #include <joybus/target.h>
 
@@ -23,6 +24,13 @@ struct joybus_n64_controller;
 typedef void (*joybus_n64_controller_reset_cb_t)(struct joybus_n64_controller *controller);
 
 /**
+ * N64 controller accessory, such as a rumble pak or memory pak.
+ */
+struct joybus_n64_accessory {
+  // TODO
+};
+
+/**
  * N64 controller Joybus target.
  */
 struct joybus_n64_controller {
@@ -36,6 +44,15 @@ struct joybus_n64_controller {
 
   /** Callback for controller reset events */
   joybus_n64_controller_reset_cb_t on_reset;
+
+  /** Currently attached accessory */
+  struct joybus_n64_accessory *accessory;
+
+  /** CRC for data transfer commands */
+  uint8_t crc;
+
+  /** Response buffer */
+  uint8_t response[JOYBUS_BLOCK_SIZE];
 };
 
 /**
@@ -45,9 +62,8 @@ struct joybus_n64_controller {
  * handlers for OEM N64 controller commands.
  *
  * @param controller the controller to initialize
- * @param type the device type flags
  */
-void joybus_n64_controller_init(struct joybus_n64_controller *controller, uint16_t type);
+void joybus_n64_controller_init(struct joybus_n64_controller *controller);
 
 /**
  * Set the reset callback for the controller.
@@ -61,4 +77,19 @@ void joybus_n64_controller_init(struct joybus_n64_controller *controller, uint16
 void joybus_n64_controller_set_reset_callback(struct joybus_n64_controller *controller,
                                               joybus_n64_controller_reset_cb_t callback);
 
+/**
+ * Attach an accessory to the controller.
+ *
+ * @param controller the controller to attach the accessory to
+ * @param accessory the accessory to attach
+ */
+void joybus_n64_controller_attach_accessory(struct joybus_n64_controller *controller,
+                                            struct joybus_n64_accessory *accessory);
+
+/**
+ * Detach the currently attached accessory from the controller.
+ *
+ * @param controller the controller to detach the accessory from
+ */
+void joybus_n64_controller_detach_accessory(struct joybus_n64_controller *controller);
 /** @} */

--- a/include/joybus/target/n64_controller.h
+++ b/include/joybus/target/n64_controller.h
@@ -1,6 +1,6 @@
 /**
  * @defgroup joybus_target_n64_controller N64 Controller Target
- * N64 controller Joybus target
+ * Joybus target implementation for standard N64 controllers.
  * @ingroup joybus_target
  * @{
  */
@@ -14,7 +14,7 @@
 
 struct joybus_n64_controller;
 
-/** Macro to cast to a N64 controller target */
+/// Macro to cast from a generic Joybus target to an N64 controller target
 #define JOYBUS_N64_CONTROLLER(target) ((struct joybus_n64_controller *)(target))
 
 /**
@@ -28,31 +28,32 @@ typedef void (*joybus_n64_controller_reset_cb_t)(struct joybus_n64_controller *c
  * N64 controller Joybus target.
  */
 struct joybus_n64_controller {
+  /// Base target interface
   struct joybus_target base;
 
-  /** Controller ID */
+  /// Controller ID
   uint8_t id[3];
 
-  /** Current input state */
+  /// Current input state
   struct joybus_n64_controller_input input;
 
-  /** Callback for controller reset events */
+  /// Callback for controller reset events
   joybus_n64_controller_reset_cb_t on_reset;
 
-  /** Currently attached accessory */
+  /// Currently attached accessory (if any)
   struct joybus_n64_accessory *accessory;
 
-  /** CRC for data transfer commands */
+  /// CRC for data transfer commands
   uint8_t crc;
 
-  /** Response buffer */
+  /// Response buffer
   uint8_t response[JOYBUS_BLOCK_SIZE];
 };
 
 /**
  * Initialize an N64 controller.
  *
- * This function sets up the initial state, and registers SI command
+ * This function sets up the initial state, and registers Joybus command
  * handlers for OEM N64 controller commands.
  *
  * @param controller the controller to initialize

--- a/include/joybus/target/n64_rumble_pak.h
+++ b/include/joybus/target/n64_rumble_pak.h
@@ -1,6 +1,6 @@
 /**
  * @defgroup joybus_target_n64_rumble_pak N64 Rumble Pak
- * Virtual N64 rumble pak accessory
+ * N64 rumble pak accessory which exposes a callback for motor state changes.
  * @ingroup joybus_target_n64_accessory
  * @{
  */
@@ -14,17 +14,11 @@
 
 struct joybus_n64_rumble_pak;
 
-/** Macro to cast to a rumble pak */
+/// Macro to cast from a generic N64 accessory to a rumble pak
 #define JOYBUS_N64_RUMBLE_PAK(pak) ((struct joybus_n64_rumble_pak *)(pak))
 
 /**
  * Callback type for rumble pak motor state change events.
- *
- * Invoked when the host writes to the motor control region and the
- * requested motor state differs from the current state.
- *
- * NOTE: Called from interrupt context. Do not perform blocking
- *       operations within the callback.
  *
  * @param pak    the rumble pak whose motor state changed
  * @param active true if the motor should be on, false if off
@@ -32,18 +26,16 @@ struct joybus_n64_rumble_pak;
 typedef void (*joybus_n64_rumble_pak_motor_cb_t)(struct joybus_n64_rumble_pak *pak, bool active);
 
 /**
- * Virtual rumble pak accessory.
- *
- * Presents as an OEM rumble pak: returns the rumble pak signature on
- * probe reads, and fires a callback when the host toggles the motor.
+ * N64 Rumble Pak accessory.
  */
 struct joybus_n64_rumble_pak {
+  /// Base accessory interface
   struct joybus_n64_accessory base;
 
-  /** Current motor state */
+  /// Current motor state
   bool active;
 
-  /** Callback for motor state change events */
+  /// Callback for motor state change events
   joybus_n64_rumble_pak_motor_cb_t on_motor_change;
 };
 

--- a/include/joybus/target/n64_rumble_pak.h
+++ b/include/joybus/target/n64_rumble_pak.h
@@ -1,0 +1,68 @@
+/**
+ * @defgroup joybus_target_n64_rumble_pak N64 Rumble Pak
+ * Virtual N64 rumble pak accessory
+ * @ingroup joybus_target_n64_accessory
+ * @{
+ */
+
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include <joybus/target/n64_accessory.h>
+
+struct joybus_n64_rumble_pak;
+
+/** Macro to cast to a rumble pak */
+#define JOYBUS_N64_RUMBLE_PAK(pak) ((struct joybus_n64_rumble_pak *)(pak))
+
+/**
+ * Callback type for rumble pak motor state change events.
+ *
+ * Invoked when the host writes to the motor control region and the
+ * requested motor state differs from the current state.
+ *
+ * NOTE: Called from interrupt context. Do not perform blocking
+ *       operations within the callback.
+ *
+ * @param pak    the rumble pak whose motor state changed
+ * @param active true if the motor should be on, false if off
+ */
+typedef void (*joybus_n64_rumble_pak_motor_cb_t)(struct joybus_n64_rumble_pak *pak, bool active);
+
+/**
+ * Virtual rumble pak accessory.
+ *
+ * Presents as an OEM rumble pak: returns the rumble pak signature on
+ * probe reads, and fires a callback when the host toggles the motor.
+ */
+struct joybus_n64_rumble_pak {
+  struct joybus_n64_accessory base;
+
+  /** Current motor state */
+  bool active;
+
+  /** Callback for motor state change events */
+  joybus_n64_rumble_pak_motor_cb_t on_motor_change;
+};
+
+/**
+ * Initialize a rumble pak.
+ *
+ * @param pak the rumble pak to initialize
+ */
+void joybus_n64_rumble_pak_init(struct joybus_n64_rumble_pak *pak);
+
+/**
+ * Set the motor state change callback for the rumble pak.
+ *
+ * NOTE: Motor callbacks are called from interrupt context, do not perform
+ *       any blocking operations within the callback.
+ *
+ * @param pak      the rumble pak to set the callback for
+ * @param callback the callback function
+ */
+void joybus_n64_rumble_pak_set_motor_callback(struct joybus_n64_rumble_pak *pak,
+                                              joybus_n64_rumble_pak_motor_cb_t callback);
+/** @} */

--- a/libjoybus.code-workspace
+++ b/libjoybus.code-workspace
@@ -56,6 +56,7 @@
     "C_Cpp.autoAddFileAssociations": false,
     "files.associations": {
       "*.h": "c"
-    }
+    },
+    "search.useParentIgnoreFiles": true
   }
 }

--- a/libjoybus.slcc
+++ b/libjoybus.slcc
@@ -25,3 +25,4 @@ source:
   - path: src/host/n64.c
   - path: src/target/gc_controller.c
   - path: src/target/n64_controller.c
+  - path: src/target/n64_rumble_pak.c

--- a/src/backend/gecko_sdk/joybus.c
+++ b/src/backend/gecko_sdk/joybus.c
@@ -426,7 +426,8 @@ static bool ldma_tx_handler(unsigned int chan, unsigned int iteration, void *use
       } else {
         // No reply expected, go idle and call the transfer complete callback
         data->state = BUS_STATE_HOST_IDLE;
-        data->done_callback(bus, 0, data->done_user_data);
+        if (data->done_callback)
+          data->done_callback(bus, 0, data->done_user_data);
       }
     } else if (data->state == BUS_STATE_TARGET_TX) {
       // If we are handling a command response (target mode), and a target is

--- a/src/backend/loopback/joybus.c
+++ b/src/backend/loopback/joybus.c
@@ -42,13 +42,16 @@ static int joybus_loopback_transfer(struct joybus *bus, const uint8_t *write_buf
       break;
     } else if (rc < 0) {
       // Error handling command, or command not supported
-      callback(bus, 0, user_data);
+      if (callback)
+        callback(bus, 0, user_data);
+
       return rc;
     }
   }
 
   // Call the transfer complete callback
-  callback(bus, response_length, user_data);
+  if (callback)
+    callback(bus, response_length, user_data);
 
   return 0;
 }

--- a/src/backend/rp2xxx/joybus.c
+++ b/src/backend/rp2xxx/joybus.c
@@ -217,8 +217,9 @@ static inline void target_byte_received(struct joybus *bus)
 {
   struct joybus_rp2xxx_data *data = &JOYBUS_RP2XXX(bus)->data;
 
-  // Cancel the transfer timeout
-  cancel_alarm(data->rx_timeout_alarm);
+  // Cancel the transfer timeout (only armed after the first byte)
+  if (data->read_count > 0)
+    cancel_alarm(data->rx_timeout_alarm);
 
   // Save the received byte in the buffer
   data->read_buf[data->read_count] = pio_sm_get(data->pio, data->pio_sm) & 0xFF;

--- a/src/checksum.c
+++ b/src/checksum.c
@@ -49,3 +49,8 @@ uint8_t joybus_address_checksum(uint16_t addr)
 
   return sum & 0x1F;
 }
+
+bool joybus_address_checksum_valid(uint16_t addr)
+{
+  return joybus_address_checksum(addr) == (addr & 0x1F);
+}

--- a/src/target/n64_controller.c
+++ b/src/target/n64_controller.c
@@ -1,8 +1,18 @@
+#include <stdbool.h>
 #include <string.h>
 
+#include <joybus/checksum.h>
 #include <joybus/commands.h>
 #include <joybus/errors.h>
 #include <joybus/target/n64_controller.h>
+
+// Helper to check if an accessory is currently read for accessory read/write commands
+// An accessory is "ready" when it is present and accessory changed flag has been cleared
+static inline bool accessory_ready(struct joybus_n64_controller *controller)
+{
+  uint8_t status = joybus_id_get_status(controller->id);
+  return controller->accessory && (status & JOYBUS_ID_N64_ACCESSORY_CHANGED) != JOYBUS_ID_N64_ACCESSORY_CHANGED;
+}
 
 /**
  * Handle "reset" commands.
@@ -32,8 +42,19 @@ static int handle_reset(struct joybus_n64_controller *controller, const uint8_t 
 static int handle_identify(struct joybus_n64_controller *controller, const uint8_t *command, uint8_t bytes_read,
                            joybus_target_response_cb_t send_response, void *user_data)
 {
+  // Snapshot the controller ID into the response buffer so id can be mutated below
+  memcpy(controller->response, controller->id, sizeof(controller->id));
+
   // Respond with the controller ID
-  send_response(controller->id, JOYBUS_CMD_IDENTIFY_RX, user_data);
+  send_response(controller->response, JOYBUS_CMD_IDENTIFY_RX, user_data);
+
+  // After reporting "accessory changed", transition to "accessory present"
+  uint8_t status = joybus_id_get_status(controller->id);
+  if ((status & JOYBUS_ID_N64_ACCESSORY_CHANGED) == JOYBUS_ID_N64_ACCESSORY_CHANGED)
+    joybus_id_clear_status_flags(controller->id, JOYBUS_ID_N64_ACCESSORY_ABSENT);
+
+  // Clear any latched checksum error — reported once, then cleared
+  joybus_id_clear_status_flags(controller->id, JOYBUS_ID_N64_CHECKSUM_ERROR);
 
   return 0;
 }
@@ -53,6 +74,98 @@ static int handle_read(struct joybus_n64_controller *controller, const uint8_t *
   return 0;
 }
 
+/**
+ * Handle "accessory read" commands, to read data from a connected accessory such as a rumble pak or memory pak.
+ *
+ * Command:         {0x02, address[2]}
+ * Response:        32 bytes of accessory data, and a 1-byte CRC8
+ *
+ */
+static int handle_accessory_read(struct joybus_n64_controller *controller, const uint8_t *command, uint8_t bytes_read,
+                                 joybus_target_response_cb_t send_response, void *user_data)
+{
+  // Wait until the full command is received before responding
+  if (bytes_read < JOYBUS_CMD_N64_ACCESSORY_READ_TX)
+    return JOYBUS_CMD_N64_ACCESSORY_READ_TX - bytes_read;
+
+  // Extract the address from the command
+  uint16_t addr = ((uint16_t)command[1] << 8) | command[2];
+
+  // Validate the address checksum
+  bool checksum_valid = joybus_address_checksum_valid(addr);
+
+  // Set or clear the checksum error flag in the controller ID
+  if (checksum_valid) {
+    joybus_id_clear_status_flags(controller->id, JOYBUS_ID_N64_CHECKSUM_ERROR);
+  } else {
+    joybus_id_set_status_flags(controller->id, JOYBUS_ID_N64_CHECKSUM_ERROR);
+  }
+
+  // Prepare and send the response
+  if (accessory_ready(controller) && checksum_valid) {
+    // TODO: Read data from attached accessory
+    // memset(controller->response, 0, JOYBUS_CMD_N64_ACCESSORY_READ_RX);
+    // send_response(controller->response, JOYBUS_CMD_N64_ACCESSORY_READ_RX, user_data);
+  } else {
+    // Prepare a "zero" response with the "no pak" CRC
+    memset(controller->response, 0, JOYBUS_CMD_N64_ACCESSORY_READ_RX);
+    controller->response[32] = 0xFF;
+
+    // Send the response
+    send_response(controller->response, JOYBUS_CMD_N64_ACCESSORY_READ_RX, user_data);
+  }
+
+  return 0;
+}
+
+/**
+ * Handle "accessory write" commands, to write data to a connected accessory such as a rumble pak or memory pak.
+ *
+ * Command:         {0x03, address[2], data[32]}
+ * Response:        A 1-byte CRC8 of the written data
+ *
+ */
+static int handle_accessory_write(struct joybus_n64_controller *controller, const uint8_t *command, uint8_t bytes_read,
+                                  joybus_target_response_cb_t send_response, void *user_data)
+{
+  // First 3 bytes are command and address
+  if (bytes_read == 3) {
+    // Extract the address from the command
+    uint16_t addr = ((uint16_t)command[1] << 8) | command[2];
+
+    // Set or clear the checksum error flag
+    if (joybus_address_checksum_valid(addr)) {
+      joybus_id_clear_status_flags(controller->id, JOYBUS_ID_N64_CHECKSUM_ERROR);
+    } else {
+      joybus_id_set_status_flags(controller->id, JOYBUS_ID_N64_CHECKSUM_ERROR);
+    }
+
+    // Reset the running CRC for the payload bytes
+    controller->crc = 0;
+
+    return JOYBUS_CMD_N64_ACCESSORY_WRITE_TX - bytes_read;
+  }
+
+  // Subsequent bytes are payload, accumulate the CRC
+  controller->crc = joybus_crc8_update(controller->crc, command[bytes_read - 1]);
+
+  // Full payload received, respond with the CRC
+  if (bytes_read == JOYBUS_CMD_N64_ACCESSORY_WRITE_TX) {
+    if (accessory_ready(controller)) {
+      // TODO: Write data to attached accessory?
+      // NOTE: Should we write all at once, or stream as bytes are received?
+    } else {
+      // XOR the CRC with 0xFF if no accessory is present
+      controller->crc ^= 0xFF;
+    }
+
+    // Send the CRC response
+    send_response(&controller->crc, JOYBUS_CMD_N64_ACCESSORY_WRITE_RX, user_data);
+  }
+
+  return JOYBUS_CMD_N64_ACCESSORY_WRITE_TX - bytes_read;
+}
+
 static int n64_controller_byte_received(struct joybus_target *target, const uint8_t *command, uint8_t bytes_read,
                                         joybus_target_response_cb_t send_response, void *user_data)
 {
@@ -64,6 +177,10 @@ static int n64_controller_byte_received(struct joybus_target *target, const uint
       return handle_identify(controller, command, bytes_read, send_response, user_data);
     case JOYBUS_CMD_N64_READ:
       return handle_read(controller, command, bytes_read, send_response, user_data);
+    case JOYBUS_CMD_N64_ACCESSORY_READ:
+      return handle_accessory_read(controller, command, bytes_read, send_response, user_data);
+    case JOYBUS_CMD_N64_ACCESSORY_WRITE:
+      return handle_accessory_write(controller, command, bytes_read, send_response, user_data);
   }
 
   return -JOYBUS_ERR_NOT_SUPPORTED;
@@ -73,19 +190,46 @@ static const struct joybus_target_api n64_controller_api = {
   .byte_received = n64_controller_byte_received,
 };
 
-void joybus_n64_controller_init(struct joybus_n64_controller *controller, uint16_t type)
+void joybus_n64_controller_init(struct joybus_n64_controller *controller)
 {
+  // Start from a clean state
+  memset(controller, 0, sizeof(*controller));
+
   // Set the target callbacks
   struct joybus_target *target = JOYBUS_TARGET(controller);
   target->api                  = &n64_controller_api;
 
   // Initialize the controller ID
-  memset(controller->id, 0, sizeof(controller->id));
-  joybus_id_set_type_flags(controller->id, type);
+  joybus_id_set_type_flags(controller->id, JOYBUS_ID_N64_CONTROLLER);
+  joybus_id_set_status_flags(controller->id, JOYBUS_ID_N64_ACCESSORY_ABSENT);
 }
 
 void joybus_n64_controller_set_reset_callback(struct joybus_n64_controller *controller,
                                               joybus_n64_controller_reset_cb_t callback)
 {
   controller->on_reset = callback;
+}
+
+void joybus_n64_controller_attach_accessory(struct joybus_n64_controller *controller,
+                                            struct joybus_n64_accessory *accessory)
+{
+  // Set the accessory pointer on the controller
+  controller->accessory = accessory;
+
+  joybus_id_clear_status_flags(controller->id, JOYBUS_ID_N64_ACCESSORY_CHANGED);
+  if (((struct joybus_target *)controller)->registered) {
+    joybus_id_set_status_flags(controller->id, JOYBUS_ID_N64_ACCESSORY_CHANGED);
+  } else {
+    joybus_id_set_status_flags(controller->id, JOYBUS_ID_N64_ACCESSORY_PRESENT);
+  }
+}
+
+void joybus_n64_controller_detach_accessory(struct joybus_n64_controller *controller)
+{
+  // Clear the accessory pointer on the controller
+  controller->accessory = NULL;
+
+  // Mark the accessory as absent
+  joybus_id_clear_status_flags(controller->id, JOYBUS_ID_N64_ACCESSORY_CHANGED);
+  joybus_id_set_status_flags(controller->id, JOYBUS_ID_N64_ACCESSORY_ABSENT);
 }

--- a/src/target/n64_controller.c
+++ b/src/target/n64_controller.c
@@ -43,7 +43,9 @@ static int handle_identify(struct joybus_n64_controller *controller, const uint8
                            joybus_target_response_cb_t send_response, void *user_data)
 {
   // Snapshot the controller ID into the response buffer so id can be mutated below
-  memcpy(controller->response, controller->id, sizeof(controller->id));
+  controller->response[0] = controller->id[0];
+  controller->response[1] = controller->id[1];
+  controller->response[2] = controller->id[2];
 
   // Respond with the controller ID
   send_response(controller->response, JOYBUS_CMD_IDENTIFY_RX, user_data);

--- a/src/target/n64_controller.c
+++ b/src/target/n64_controller.c
@@ -103,13 +103,20 @@ static int handle_accessory_read(struct joybus_n64_controller *controller, const
 
   // Prepare and send the response
   if (accessory_ready(controller) && checksum_valid) {
-    // TODO: Read data from attached accessory
-    // memset(controller->response, 0, JOYBUS_CMD_N64_ACCESSORY_READ_RX);
-    // send_response(controller->response, JOYBUS_CMD_N64_ACCESSORY_READ_RX, user_data);
+    // Ask the accessory to fill the response buffer
+    uint16_t block_addr              = addr & 0xFFE0;
+    struct joybus_n64_accessory *acc = controller->accessory;
+    acc->api->read_block(acc, block_addr, controller->response);
+
+    // Calculate and append the CRC8
+    controller->response[JOYBUS_ACCESSORY_BLOCK_SIZE] = joybus_crc8(controller->response, JOYBUS_ACCESSORY_BLOCK_SIZE);
+
+    // Send the response
+    send_response(controller->response, JOYBUS_CMD_N64_ACCESSORY_READ_RX, user_data);
   } else {
     // Prepare a zero response with the "no accessory" CRC
     memset(controller->response, 0, JOYBUS_CMD_N64_ACCESSORY_READ_RX);
-    controller->response[32] = 0xFF;
+    controller->response[JOYBUS_ACCESSORY_BLOCK_SIZE] = 0xFF;
 
     // Send the response
     send_response(controller->response, JOYBUS_CMD_N64_ACCESSORY_READ_RX, user_data);
@@ -152,16 +159,23 @@ static int handle_accessory_write(struct joybus_n64_controller *controller, cons
   // Full payload received, respond with the CRC
   if (bytes_read == JOYBUS_CMD_N64_ACCESSORY_WRITE_TX) {
     bool checksum_valid = (joybus_id_get_status(controller->id) & JOYBUS_ID_N64_CHECKSUM_ERROR) == 0;
-    if (accessory_ready(controller) && checksum_valid) {
-      // TODO: Write data to attached accessory?
-      // NOTE: Should we write all at once, or stream as bytes are received?
-    } else {
-      // Mark the CRC as a "no accessory" response
+    bool ready          = accessory_ready(controller) && checksum_valid;
+
+    // Mark the CRC as "no accessory" if we're not ready to commit the write
+    if (!ready) {
       controller->crc ^= 0xFF;
     }
 
-    // Send the CRC response
+    // Send the CRC response first to keep the storage write off the response critical path
     send_response(&controller->crc, JOYBUS_CMD_N64_ACCESSORY_WRITE_RX, user_data);
+
+    // Hand the payload to the accessory after the host has its response
+    if (ready) {
+      uint16_t addr                    = ((uint16_t)command[1] << 8) | command[2];
+      uint16_t block_addr              = addr & 0xFFE0;
+      struct joybus_n64_accessory *acc = controller->accessory;
+      acc->api->write_block(acc, block_addr, &command[3]);
+    }
   }
 
   return JOYBUS_CMD_N64_ACCESSORY_WRITE_TX - bytes_read;

--- a/src/target/n64_controller.c
+++ b/src/target/n64_controller.c
@@ -107,7 +107,7 @@ static int handle_accessory_read(struct joybus_n64_controller *controller, const
     // memset(controller->response, 0, JOYBUS_CMD_N64_ACCESSORY_READ_RX);
     // send_response(controller->response, JOYBUS_CMD_N64_ACCESSORY_READ_RX, user_data);
   } else {
-    // Prepare a "zero" response with the "no pak" CRC
+    // Prepare a zero response with the "no accessory" CRC
     memset(controller->response, 0, JOYBUS_CMD_N64_ACCESSORY_READ_RX);
     controller->response[32] = 0xFF;
 
@@ -151,11 +151,12 @@ static int handle_accessory_write(struct joybus_n64_controller *controller, cons
 
   // Full payload received, respond with the CRC
   if (bytes_read == JOYBUS_CMD_N64_ACCESSORY_WRITE_TX) {
-    if (accessory_ready(controller)) {
+    bool checksum_valid = (joybus_id_get_status(controller->id) & JOYBUS_ID_N64_CHECKSUM_ERROR) == 0;
+    if (accessory_ready(controller) && checksum_valid) {
       // TODO: Write data to attached accessory?
       // NOTE: Should we write all at once, or stream as bytes are received?
     } else {
-      // XOR the CRC with 0xFF if no accessory is present
+      // Mark the CRC as a "no accessory" response
       controller->crc ^= 0xFF;
     }
 

--- a/src/target/n64_controller.c
+++ b/src/target/n64_controller.c
@@ -232,7 +232,7 @@ void joybus_n64_controller_attach_accessory(struct joybus_n64_controller *contro
   controller->accessory = accessory;
 
   joybus_id_clear_status_flags(controller->id, JOYBUS_ID_N64_ACCESSORY_CHANGED);
-  if (((struct joybus_target *)controller)->registered) {
+  if (joybus_target_is_registered(JOYBUS_TARGET(controller))) {
     joybus_id_set_status_flags(controller->id, JOYBUS_ID_N64_ACCESSORY_CHANGED);
   } else {
     joybus_id_set_status_flags(controller->id, JOYBUS_ID_N64_ACCESSORY_PRESENT);

--- a/src/target/n64_rumble_pak.c
+++ b/src/target/n64_rumble_pak.c
@@ -1,0 +1,72 @@
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+#include <joybus/commands.h>
+#include <joybus/target/n64_rumble_pak.h>
+
+// Rumble pak probe region: reads return 0x80 x 32 as the rumble pak signature
+#define RUMBLE_PAK_PROBE_BASE 0x8000
+#define RUMBLE_PAK_PROBE_END  0xA000
+
+// Rumble pak motor control region: writes toggle the motor based on buf[0]
+#define RUMBLE_PAK_MOTOR_BASE 0xC000
+#define RUMBLE_PAK_MOTOR_END  0xE000
+
+static inline bool addr_in_range(uint16_t addr, uint16_t base, uint16_t end)
+{
+  return addr >= base && addr < end;
+}
+
+static void rumble_pak_read_block(struct joybus_n64_accessory *accessory, uint16_t addr,
+                                  uint8_t buf[JOYBUS_ACCESSORY_BLOCK_SIZE])
+{
+  (void)accessory;
+
+  // The probe region returns the rumble pak signature (0x80 x 32),
+  // everything else returns zeros.
+  if (addr_in_range(addr, RUMBLE_PAK_PROBE_BASE, RUMBLE_PAK_PROBE_END)) {
+    memset(buf, 0x80, JOYBUS_ACCESSORY_BLOCK_SIZE);
+  } else {
+    memset(buf, 0x00, JOYBUS_ACCESSORY_BLOCK_SIZE);
+  }
+}
+
+static void rumble_pak_write_block(struct joybus_n64_accessory *accessory, uint16_t addr,
+                                   const uint8_t buf[JOYBUS_ACCESSORY_BLOCK_SIZE])
+{
+  struct joybus_n64_rumble_pak *pak = JOYBUS_N64_RUMBLE_PAK(accessory);
+
+  // Writes outside the motor control region are ignored
+  if (!addr_in_range(addr, RUMBLE_PAK_MOTOR_BASE, RUMBLE_PAK_MOTOR_END)) {
+    return;
+  }
+
+  // The first byte of the payload determines the motor state
+  bool active = buf[0] != 0;
+  if (active == pak->active) {
+    return;
+  }
+
+  pak->active = active;
+  if (pak->on_motor_change) {
+    pak->on_motor_change(pak, active);
+  }
+}
+
+static const struct joybus_n64_accessory_api rumble_pak_api = {
+  .read_block  = rumble_pak_read_block,
+  .write_block = rumble_pak_write_block,
+};
+
+void joybus_n64_rumble_pak_init(struct joybus_n64_rumble_pak *pak)
+{
+  memset(pak, 0, sizeof(*pak));
+  pak->base.api = &rumble_pak_api;
+}
+
+void joybus_n64_rumble_pak_set_motor_callback(struct joybus_n64_rumble_pak *pak,
+                                              joybus_n64_rumble_pak_motor_cb_t callback)
+{
+  pak->on_motor_change = callback;
+}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -26,3 +26,4 @@ add_libjoybus_test(test_wavebird target/test_wavebird.c)
 
 # N64 controller target tests
 add_libjoybus_test(test_n64_controller target/test_n64_controller.c)
+add_libjoybus_test(test_n64_rumble_pak target/test_n64_rumble_pak.c)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -23,3 +23,6 @@ add_libjoybus_test(test_checksum test_checksum.c)
 # GameCube controller target tests
 add_libjoybus_test(test_gc_controller target/test_gc_controller.c)
 add_libjoybus_test(test_wavebird target/test_wavebird.c)
+
+# N64 controller target tests
+add_libjoybus_test(test_n64_controller target/test_n64_controller.c)

--- a/test/target/test_n64_controller.c
+++ b/test/target/test_n64_controller.c
@@ -1,0 +1,291 @@
+#include <string.h>
+
+#include <joybus/bus.h>
+#include <joybus/checksum.h>
+#include <joybus/commands.h>
+#include <joybus/backend/loopback.h>
+#include <joybus/host/common.h>
+#include <joybus/host/n64.h>
+#include <joybus/target/n64_controller.h>
+
+#include "unity.h"
+
+// A loopback Joybus and an N64 controller target
+struct joybus bus;
+struct joybus_n64_controller controller;
+struct joybus_n64_accessory accessory;
+
+// Spy callback to capture responses
+static uint8_t response[JOYBUS_BLOCK_SIZE];
+static int response_len;
+static void spy(struct joybus *bus, int result, void *user_data)
+{
+  response_len = result;
+}
+
+void setUp(void)
+{
+  // Initialize the loopback bus
+  joybus_loopback_init(&bus);
+  joybus_enable(&bus);
+
+  // Initialize a standard N64 controller target — tests call joybus_target_register
+  // to simulate "power on" at the moment of their choosing
+  joybus_n64_controller_init(&controller);
+
+  // Reset response capture
+  response_len = -1;
+  memset(response, 0, sizeof(response));
+}
+
+void tearDown(void)
+{
+}
+
+// Test that the "identify" response is correct for a standard N64 controller with no accessory
+static void test_n64_controller_identify()
+{
+  // Power on (no accessory)
+  joybus_target_register(&bus, JOYBUS_TARGET(&controller));
+
+  // Send an identify command
+  joybus_identify(&bus, response, spy, NULL);
+
+  // Test device identify response is as expected
+  uint8_t expected[] = {0x05, 0x00, 0x02};
+  TEST_ASSERT_EQUAL(3, response_len);
+  TEST_ASSERT_EQUAL_HEX8_ARRAY(expected, response, 3);
+}
+
+// Test that the identify response reflects accessory state when hotplugging an accessory
+static void test_n64_controller_accessory_hotplug()
+{
+  // Power on (no accessory)
+  joybus_target_register(&bus, JOYBUS_TARGET(&controller));
+
+  // Send an identify command with no accessory attached
+  joybus_identify(&bus, response, spy, NULL);
+
+  // Test identify reports accessory absent
+  uint8_t expected_absent[] = {0x05, 0x00, 0x02};
+  TEST_ASSERT_EQUAL(3, response_len);
+  TEST_ASSERT_EQUAL_HEX8_ARRAY(expected_absent, response, 3);
+
+  // Attach an accessory
+  joybus_n64_controller_attach_accessory(&controller, &accessory);
+
+  // Send another identify command
+  joybus_identify(&bus, response, spy, NULL);
+
+  // Test identify reports accessory changed
+  uint8_t expected_changed[] = {0x05, 0x00, 0x03};
+  TEST_ASSERT_EQUAL(3, response_len);
+  TEST_ASSERT_EQUAL_HEX8_ARRAY(expected_changed, response, 3);
+
+  // Send another identify command
+  joybus_identify(&bus, response, spy, NULL);
+
+  // Test identify reports accessory present on subsequent calls
+  uint8_t expected_present[] = {0x05, 0x00, 0x01};
+  TEST_ASSERT_EQUAL(3, response_len);
+  TEST_ASSERT_EQUAL_HEX8_ARRAY(expected_present, response, 3);
+}
+
+// Test that the identify response reflects accessory state when unplugging an accessory
+static void test_n64_controller_accessory_unplug()
+{
+  // Attach an accessory and then power on
+  joybus_n64_controller_attach_accessory(&controller, &accessory);
+  joybus_target_register(&bus, JOYBUS_TARGET(&controller));
+
+  // Send an identify command
+  joybus_identify(&bus, response, spy, NULL);
+
+  // Test identify reports accessory present
+  uint8_t expected_present[] = {0x05, 0x00, 0x01};
+  TEST_ASSERT_EQUAL(3, response_len);
+  TEST_ASSERT_EQUAL_HEX8_ARRAY(expected_present, response, 3);
+
+  // Detach the accessory
+  joybus_n64_controller_detach_accessory(&controller);
+
+  // Send another identify command
+  joybus_identify(&bus, response, spy, NULL);
+
+  // Test identify reports accessory absent
+  uint8_t expected_absent[] = {0x05, 0x00, 0x02};
+  TEST_ASSERT_EQUAL(3, response_len);
+  TEST_ASSERT_EQUAL_HEX8_ARRAY(expected_absent, response, 3);
+
+  // Send another identify command
+  joybus_identify(&bus, response, spy, NULL);
+
+  // Test identify continues to report accessory absent
+  TEST_ASSERT_EQUAL(3, response_len);
+  TEST_ASSERT_EQUAL_HEX8_ARRAY(expected_absent, response, 3);
+}
+
+// Test that the identify response reports "accessory changed" when an accessory is attached before the first identify
+static void test_n64_controller_accessory_hotplug_no_initial_identify()
+{
+  // Power on (no accessory), then hotplug before any identify is sent
+  joybus_target_register(&bus, JOYBUS_TARGET(&controller));
+  joybus_n64_controller_attach_accessory(&controller, &accessory);
+
+  // Send an identify command
+  joybus_identify(&bus, response, spy, NULL);
+
+  // Test identify reports accessory changed
+  uint8_t expected_changed[] = {0x05, 0x00, 0x03};
+  TEST_ASSERT_EQUAL(3, response_len);
+  TEST_ASSERT_EQUAL_HEX8_ARRAY(expected_changed, response, 3);
+
+  // Send another identify command
+  joybus_identify(&bus, response, spy, NULL);
+
+  // Test identify reports accessory present on subsequent calls
+  uint8_t expected_present[] = {0x05, 0x00, 0x01};
+  TEST_ASSERT_EQUAL(3, response_len);
+  TEST_ASSERT_EQUAL_HEX8_ARRAY(expected_present, response, 3);
+}
+
+// Test that the checksum error flag is set after a bad-checksum accessory read, and cleared by a subsequent identify
+static void test_n64_controller_bad_checksum_cleared_by_identify()
+{
+  // Power on with accessory attached, then bring up communication via identify
+  joybus_n64_controller_attach_accessory(&controller, &accessory);
+  joybus_target_register(&bus, JOYBUS_TARGET(&controller));
+  joybus_identify(&bus, response, spy, NULL);
+
+  // Send a raw accessory read with a bad address checksum
+  uint8_t bad_read_cmd[] = {JOYBUS_CMD_N64_ACCESSORY_READ, 0x80, 0x00};
+  joybus_transfer(&bus, bad_read_cmd, sizeof(bad_read_cmd), response, JOYBUS_CMD_N64_ACCESSORY_READ_RX, spy, NULL);
+
+  // Send an identify command
+  joybus_identify(&bus, response, spy, NULL);
+
+  // Test identify reports accessory present with checksum error flag set
+  uint8_t expected_error[] = {0x05, 0x00, 0x05};
+  TEST_ASSERT_EQUAL(3, response_len);
+  TEST_ASSERT_EQUAL_HEX8_ARRAY(expected_error, response, 3);
+
+  // Send another identify command
+  joybus_identify(&bus, response, spy, NULL);
+
+  // Test identify reports accessory present with checksum error flag cleared
+  uint8_t expected_present[] = {0x05, 0x00, 0x01};
+  TEST_ASSERT_EQUAL(3, response_len);
+  TEST_ASSERT_EQUAL_HEX8_ARRAY(expected_present, response, 3);
+}
+
+// Test that the checksum error flag is cleared by a subsequent successful accessory read
+static void test_n64_controller_bad_checksum_cleared_by_successful_read()
+{
+  // Power on with accessory attached, then bring up communication via identify
+  joybus_n64_controller_attach_accessory(&controller, &accessory);
+  joybus_target_register(&bus, JOYBUS_TARGET(&controller));
+  joybus_identify(&bus, response, spy, NULL);
+
+  // Send a raw accessory read with a bad address checksum
+  uint8_t bad_read_cmd[] = {JOYBUS_CMD_N64_ACCESSORY_READ, 0x80, 0x00};
+  joybus_transfer(&bus, bad_read_cmd, sizeof(bad_read_cmd), response, JOYBUS_CMD_N64_ACCESSORY_READ_RX, spy, NULL);
+
+  // Send an accessory read with a valid address checksum
+  joybus_n64_accessory_read(&bus, 0x8000, response, spy, NULL);
+
+  // Send an identify command
+  joybus_identify(&bus, response, spy, NULL);
+
+  // Test identify reports accessory present with no checksum error flag set
+  uint8_t expected_present[] = {0x05, 0x00, 0x01};
+  TEST_ASSERT_EQUAL(3, response_len);
+  TEST_ASSERT_EQUAL_HEX8_ARRAY(expected_present, response, 3);
+}
+
+// Test that accessory_read with no accessory attached returns 32 zeroes and the "pak absent" CRC
+static void test_n64_controller_accessory_read_no_accessory()
+{
+  // Power on (no accessory)
+  joybus_target_register(&bus, JOYBUS_TARGET(&controller));
+
+  // Send an accessory read with a valid address
+  joybus_n64_accessory_read(&bus, 0x8000, response, spy, NULL);
+
+  // Expect 32 zero bytes followed by 0xFF (CRC8 of 32 zeroes is 0x00, XORed with 0xFF for "no pak")
+  uint8_t expected[JOYBUS_CMD_N64_ACCESSORY_READ_RX] = {0};
+  expected[32]                                       = 0xFF;
+  TEST_ASSERT_EQUAL(JOYBUS_CMD_N64_ACCESSORY_READ_RX, response_len);
+  TEST_ASSERT_EQUAL_HEX8_ARRAY(expected, response, JOYBUS_CMD_N64_ACCESSORY_READ_RX);
+}
+
+// Test that accessory_write with no accessory attached is accepted and returns the "pak absent" CRC
+static void test_n64_controller_accessory_write_no_accessory()
+{
+  // Power on (no accessory)
+  joybus_target_register(&bus, JOYBUS_TARGET(&controller));
+
+  // Send an accessory write with a valid address and 32 bytes of 0x80
+  uint8_t data[JOYBUS_ACCESSORY_DATA_SIZE];
+  memset(data, 0x80, sizeof(data));
+  joybus_n64_accessory_write(&bus, 0x8000, data, response, spy, NULL);
+
+  // Expect the response to be crc8(data) ^ 0xFF (the "no pak" marker)
+  uint8_t expected = joybus_crc8(data, sizeof(data)) ^ 0xFF;
+  TEST_ASSERT_EQUAL(JOYBUS_CMD_N64_ACCESSORY_WRITE_RX, response_len);
+  TEST_ASSERT_EQUAL_HEX8(expected, response[0]);
+}
+
+// Test that accessory_read on a hotplugged accessory (still in CHANGED state, no identify yet)
+// behaves as if no accessory is present
+static void test_n64_controller_accessory_read_while_changed()
+{
+  // Power on (no accessory), then hotplug — status is now CHANGED, identify not yet called
+  joybus_target_register(&bus, JOYBUS_TARGET(&controller));
+  joybus_n64_controller_attach_accessory(&controller, &accessory);
+
+  // Send an accessory read with a valid address
+  joybus_n64_accessory_read(&bus, 0x8000, response, spy, NULL);
+
+  // Expect the "no pak" response — 32 zero bytes followed by 0xFF
+  uint8_t expected[JOYBUS_CMD_N64_ACCESSORY_READ_RX] = {0};
+  expected[32]                                       = 0xFF;
+  TEST_ASSERT_EQUAL(JOYBUS_CMD_N64_ACCESSORY_READ_RX, response_len);
+  TEST_ASSERT_EQUAL_HEX8_ARRAY(expected, response, JOYBUS_CMD_N64_ACCESSORY_READ_RX);
+}
+
+// Test that accessory_write on a hotplugged accessory (still in CHANGED state, no identify yet)
+// behaves as if no accessory is present
+static void test_n64_controller_accessory_write_while_changed()
+{
+  // Power on (no accessory), then hotplug — status is now CHANGED, identify not yet called
+  joybus_target_register(&bus, JOYBUS_TARGET(&controller));
+  joybus_n64_controller_attach_accessory(&controller, &accessory);
+
+  // Send an accessory write with a valid address and 32 bytes of 0x80
+  uint8_t data[JOYBUS_ACCESSORY_DATA_SIZE];
+  memset(data, 0x80, sizeof(data));
+  joybus_n64_accessory_write(&bus, 0x8000, data, response, spy, NULL);
+
+  // Expect the "no pak" response — crc8(data) ^ 0xFF
+  uint8_t expected = joybus_crc8(data, sizeof(data)) ^ 0xFF;
+  TEST_ASSERT_EQUAL(JOYBUS_CMD_N64_ACCESSORY_WRITE_RX, response_len);
+  TEST_ASSERT_EQUAL_HEX8(expected, response[0]);
+}
+
+int main(int argc, char **argv)
+{
+  UNITY_BEGIN();
+
+  RUN_TEST(test_n64_controller_identify);
+  RUN_TEST(test_n64_controller_accessory_hotplug);
+  RUN_TEST(test_n64_controller_accessory_unplug);
+  RUN_TEST(test_n64_controller_accessory_hotplug_no_initial_identify);
+  RUN_TEST(test_n64_controller_bad_checksum_cleared_by_identify);
+  RUN_TEST(test_n64_controller_bad_checksum_cleared_by_successful_read);
+  RUN_TEST(test_n64_controller_accessory_read_no_accessory);
+  RUN_TEST(test_n64_controller_accessory_write_no_accessory);
+  RUN_TEST(test_n64_controller_accessory_read_while_changed);
+  RUN_TEST(test_n64_controller_accessory_write_while_changed);
+
+  return UNITY_END();
+}

--- a/test/target/test_n64_controller.c
+++ b/test/target/test_n64_controller.c
@@ -301,6 +301,46 @@ static void test_n64_controller_accessory_write_while_changed()
   TEST_ASSERT_EQUAL_HEX8(expected, response[0]);
 }
 
+// Test that a bad-checksum read with the accessory present returns the "no pak" response
+static void test_n64_controller_accessory_read_bad_checksum()
+{
+  // Power on with accessory attached (status = PRESENT, not CHANGED)
+  joybus_n64_controller_attach_accessory(&controller, &accessory);
+  joybus_target_register(&bus, JOYBUS_TARGET(&controller));
+
+  // Send a raw accessory read with a bad address checksum
+  uint8_t bad_read_cmd[] = {JOYBUS_CMD_N64_ACCESSORY_READ, 0x80, 0x00};
+  joybus_transfer(&bus, bad_read_cmd, sizeof(bad_read_cmd), response, JOYBUS_CMD_N64_ACCESSORY_READ_RX, spy, NULL);
+
+  // Expect 32 zero bytes followed by 0xFF — the "no pak" CRC
+  uint8_t expected[JOYBUS_CMD_N64_ACCESSORY_READ_RX] = {0};
+  expected[32]                                       = 0xFF;
+  TEST_ASSERT_EQUAL(JOYBUS_CMD_N64_ACCESSORY_READ_RX, response_len);
+  TEST_ASSERT_EQUAL_HEX8_ARRAY(expected, response, JOYBUS_CMD_N64_ACCESSORY_READ_RX);
+}
+
+// Test that a bad-checksum write with the accessory present returns the "no pak" response
+static void test_n64_controller_accessory_write_bad_checksum()
+{
+  // Power on with accessory attached (status = PRESENT, not CHANGED)
+  joybus_n64_controller_attach_accessory(&controller, &accessory);
+  joybus_target_register(&bus, JOYBUS_TARGET(&controller));
+
+  // Build a raw accessory write with a bad address checksum (low 5 bits zero, doesn't match)
+  uint8_t bad_write_cmd[JOYBUS_CMD_N64_ACCESSORY_WRITE_TX];
+  bad_write_cmd[0] = JOYBUS_CMD_N64_ACCESSORY_WRITE;
+  bad_write_cmd[1] = 0x80;
+  bad_write_cmd[2] = 0x00;
+  memset(&bad_write_cmd[3], 0x80, JOYBUS_ACCESSORY_DATA_SIZE);
+
+  joybus_transfer(&bus, bad_write_cmd, sizeof(bad_write_cmd), response, JOYBUS_CMD_N64_ACCESSORY_WRITE_RX, spy, NULL);
+
+  // Expect crc8(data) ^ 0xFF — the "no pak" marker
+  uint8_t expected = joybus_crc8(&bad_write_cmd[3], JOYBUS_ACCESSORY_DATA_SIZE) ^ 0xFF;
+  TEST_ASSERT_EQUAL(JOYBUS_CMD_N64_ACCESSORY_WRITE_RX, response_len);
+  TEST_ASSERT_EQUAL_HEX8(expected, response[0]);
+}
+
 int main(int argc, char **argv)
 {
   UNITY_BEGIN();
@@ -316,6 +356,8 @@ int main(int argc, char **argv)
   RUN_TEST(test_n64_controller_accessory_write_no_accessory);
   RUN_TEST(test_n64_controller_accessory_read_while_changed);
   RUN_TEST(test_n64_controller_accessory_write_while_changed);
+  RUN_TEST(test_n64_controller_accessory_read_bad_checksum);
+  RUN_TEST(test_n64_controller_accessory_write_bad_checksum);
 
   return UNITY_END();
 }

--- a/test/target/test_n64_controller.c
+++ b/test/target/test_n64_controller.c
@@ -23,6 +23,13 @@ static void spy(struct joybus *bus, int result, void *user_data)
   response_len = result;
 }
 
+// Track reset callback invocations
+static int reset_callback_count;
+static void on_reset(struct joybus_n64_controller *controller)
+{
+  reset_callback_count++;
+}
+
 void setUp(void)
 {
   // Initialize the loopback bus
@@ -36,10 +43,34 @@ void setUp(void)
   // Reset response capture
   response_len = -1;
   memset(response, 0, sizeof(response));
+
+  // Reset reset-callback tracking
+  reset_callback_count = 0;
 }
 
 void tearDown(void)
 {
+}
+
+// Test that reset returns the controller ID and invokes the reset callback
+static void test_n64_controller_reset()
+{
+  // Register the reset callback before "power on"
+  joybus_n64_controller_set_reset_callback(&controller, on_reset);
+
+  // Power on (no accessory)
+  joybus_target_register(&bus, JOYBUS_TARGET(&controller));
+
+  // Send a reset command
+  joybus_reset(&bus, response, spy, NULL);
+
+  // Expect the response to be the controller ID
+  uint8_t expected[] = {0x05, 0x00, 0x02};
+  TEST_ASSERT_EQUAL(3, response_len);
+  TEST_ASSERT_EQUAL_HEX8_ARRAY(expected, response, 3);
+
+  // Expect the reset callback to have fired exactly once
+  TEST_ASSERT_EQUAL(1, reset_callback_count);
 }
 
 // Test that the "identify" response is correct for a standard N64 controller with no accessory
@@ -235,8 +266,7 @@ static void test_n64_controller_accessory_write_no_accessory()
   TEST_ASSERT_EQUAL_HEX8(expected, response[0]);
 }
 
-// Test that accessory_read on a hotplugged accessory (still in CHANGED state, no identify yet)
-// behaves as if no accessory is present
+// Test that accessory_read on a non-acked hotplugged accessory behaves as if no accessory is present
 static void test_n64_controller_accessory_read_while_changed()
 {
   // Power on (no accessory), then hotplug — status is now CHANGED, identify not yet called
@@ -253,8 +283,7 @@ static void test_n64_controller_accessory_read_while_changed()
   TEST_ASSERT_EQUAL_HEX8_ARRAY(expected, response, JOYBUS_CMD_N64_ACCESSORY_READ_RX);
 }
 
-// Test that accessory_write on a hotplugged accessory (still in CHANGED state, no identify yet)
-// behaves as if no accessory is present
+// Test that accessory_write on a non-acked hotplugged accessory behaves as if no accessory is present
 static void test_n64_controller_accessory_write_while_changed()
 {
   // Power on (no accessory), then hotplug — status is now CHANGED, identify not yet called
@@ -276,6 +305,7 @@ int main(int argc, char **argv)
 {
   UNITY_BEGIN();
 
+  RUN_TEST(test_n64_controller_reset);
   RUN_TEST(test_n64_controller_identify);
   RUN_TEST(test_n64_controller_accessory_hotplug);
   RUN_TEST(test_n64_controller_accessory_unplug);

--- a/test/target/test_n64_controller.c
+++ b/test/target/test_n64_controller.c
@@ -10,6 +10,24 @@
 
 #include "unity.h"
 
+// Dummy accessory backend
+static void dummy_read_block(struct joybus_n64_accessory *acc, uint16_t addr, uint8_t buf[JOYBUS_ACCESSORY_BLOCK_SIZE])
+{
+  // Return 32 zero bytes for all reads
+  memset(buf, 0, JOYBUS_ACCESSORY_BLOCK_SIZE);
+}
+
+static void dummy_write_block(struct joybus_n64_accessory *acc, uint16_t addr,
+                              const uint8_t buf[JOYBUS_ACCESSORY_BLOCK_SIZE])
+{
+  // No-op
+}
+
+static const struct joybus_n64_accessory_api dummy_accessory_api = {
+  .read_block  = dummy_read_block,
+  .write_block = dummy_write_block,
+};
+
 // A loopback Joybus and an N64 controller target
 struct joybus bus;
 struct joybus_n64_controller controller;
@@ -39,6 +57,9 @@ void setUp(void)
   // Initialize a standard N64 controller target — tests call joybus_target_register
   // to simulate "power on" at the moment of their choosing
   joybus_n64_controller_init(&controller);
+
+  // Wire up the dummy accessory backend
+  accessory.api = &dummy_accessory_api;
 
   // Reset response capture
   response_len = -1;
@@ -256,7 +277,7 @@ static void test_n64_controller_accessory_write_no_accessory()
   joybus_target_register(&bus, JOYBUS_TARGET(&controller));
 
   // Send an accessory write with a valid address and 32 bytes of 0x80
-  uint8_t data[JOYBUS_ACCESSORY_DATA_SIZE];
+  uint8_t data[JOYBUS_ACCESSORY_BLOCK_SIZE];
   memset(data, 0x80, sizeof(data));
   joybus_n64_accessory_write(&bus, 0x8000, data, response, spy, NULL);
 
@@ -291,7 +312,7 @@ static void test_n64_controller_accessory_write_while_changed()
   joybus_n64_controller_attach_accessory(&controller, &accessory);
 
   // Send an accessory write with a valid address and 32 bytes of 0x80
-  uint8_t data[JOYBUS_ACCESSORY_DATA_SIZE];
+  uint8_t data[JOYBUS_ACCESSORY_BLOCK_SIZE];
   memset(data, 0x80, sizeof(data));
   joybus_n64_accessory_write(&bus, 0x8000, data, response, spy, NULL);
 
@@ -331,12 +352,12 @@ static void test_n64_controller_accessory_write_bad_checksum()
   bad_write_cmd[0] = JOYBUS_CMD_N64_ACCESSORY_WRITE;
   bad_write_cmd[1] = 0x80;
   bad_write_cmd[2] = 0x00;
-  memset(&bad_write_cmd[3], 0x80, JOYBUS_ACCESSORY_DATA_SIZE);
+  memset(&bad_write_cmd[3], 0x80, JOYBUS_ACCESSORY_BLOCK_SIZE);
 
   joybus_transfer(&bus, bad_write_cmd, sizeof(bad_write_cmd), response, JOYBUS_CMD_N64_ACCESSORY_WRITE_RX, spy, NULL);
 
   // Expect crc8(data) ^ 0xFF — the "no pak" marker
-  uint8_t expected = joybus_crc8(&bad_write_cmd[3], JOYBUS_ACCESSORY_DATA_SIZE) ^ 0xFF;
+  uint8_t expected = joybus_crc8(&bad_write_cmd[3], JOYBUS_ACCESSORY_BLOCK_SIZE) ^ 0xFF;
   TEST_ASSERT_EQUAL(JOYBUS_CMD_N64_ACCESSORY_WRITE_RX, response_len);
   TEST_ASSERT_EQUAL_HEX8(expected, response[0]);
 }

--- a/test/target/test_n64_rumble_pak.c
+++ b/test/target/test_n64_rumble_pak.c
@@ -1,0 +1,211 @@
+#include <stdbool.h>
+#include <string.h>
+
+#include <joybus/bus.h>
+#include <joybus/checksum.h>
+#include <joybus/commands.h>
+#include <joybus/backend/loopback.h>
+#include <joybus/host/common.h>
+#include <joybus/host/n64.h>
+#include <joybus/target/n64_controller.h>
+#include <joybus/target/n64_rumble_pak.h>
+
+#include "unity.h"
+
+// A loopback Joybus, an N64 controller, and a rumble pak
+struct joybus bus;
+struct joybus_n64_controller controller;
+struct joybus_n64_rumble_pak rumble_pak;
+
+// Spy callback to capture responses
+static uint8_t response[JOYBUS_BLOCK_SIZE];
+static int response_len;
+static void spy(struct joybus *bus, int result, void *user_data)
+{
+  response_len = result;
+}
+
+// Track motor callback invocations
+static int motor_callback_count;
+static bool last_motor_state;
+static void on_motor_change(struct joybus_n64_rumble_pak *pak, bool active)
+{
+  motor_callback_count++;
+  last_motor_state = active;
+}
+
+// Track accessory detection results
+static int detect_callback_count;
+static int detected_accessory_type;
+static void on_accessory_detected(int accessory_type, void *user_data)
+{
+  detect_callback_count++;
+  detected_accessory_type = accessory_type;
+}
+
+void setUp(void)
+{
+  // Initialize the loopback bus
+  joybus_loopback_init(&bus);
+  joybus_enable(&bus);
+
+  // Initialize the controller and rumble pak, attach the pak, power on
+  joybus_n64_controller_init(&controller);
+  joybus_n64_rumble_pak_init(&rumble_pak);
+  joybus_n64_controller_attach_accessory(&controller, JOYBUS_N64_ACCESSORY(&rumble_pak));
+  joybus_target_register(&bus, JOYBUS_TARGET(&controller));
+
+  // Bring up communication so accessory reads/writes are honored
+  joybus_identify(&bus, response, spy, NULL);
+
+  // Wire up the motor callback
+  joybus_n64_rumble_pak_set_motor_callback(&rumble_pak, on_motor_change);
+
+  // Reset response capture
+  response_len = -1;
+  memset(response, 0, sizeof(response));
+
+  // Reset motor tracking
+  motor_callback_count = 0;
+  last_motor_state     = false;
+
+  // Reset detection tracking
+  detect_callback_count   = 0;
+  detected_accessory_type = -1;
+}
+
+void tearDown(void)
+{
+}
+
+// Test that a read from the probe region returns the rumble pak signature (0x80 x 32) plus valid CRC
+static void test_n64_rumble_pak_probe_read_returns_signature()
+{
+  joybus_n64_accessory_read(&bus, 0x8000, response, spy, NULL);
+
+  uint8_t expected[JOYBUS_CMD_N64_ACCESSORY_READ_RX];
+  memset(expected, 0x80, JOYBUS_ACCESSORY_BLOCK_SIZE);
+  expected[JOYBUS_ACCESSORY_BLOCK_SIZE] = joybus_crc8(expected, JOYBUS_ACCESSORY_BLOCK_SIZE);
+
+  TEST_ASSERT_EQUAL(JOYBUS_CMD_N64_ACCESSORY_READ_RX, response_len);
+  TEST_ASSERT_EQUAL_HEX8_ARRAY(expected, response, JOYBUS_CMD_N64_ACCESSORY_READ_RX);
+}
+
+// Test that the OEM detection sequence (write 0xFE to probe, then read) returns the rumble pak signature
+static void test_n64_rumble_pak_detection_sequence()
+{
+  uint8_t probe_write[JOYBUS_ACCESSORY_BLOCK_SIZE];
+  memset(probe_write, 0xFE, sizeof(probe_write));
+  joybus_n64_accessory_write(&bus, 0x8000, probe_write, response, spy, NULL);
+
+  joybus_n64_accessory_read(&bus, 0x8000, response, spy, NULL);
+
+  uint8_t expected[JOYBUS_CMD_N64_ACCESSORY_READ_RX];
+  memset(expected, 0x80, JOYBUS_ACCESSORY_BLOCK_SIZE);
+  expected[JOYBUS_ACCESSORY_BLOCK_SIZE] = joybus_crc8(expected, JOYBUS_ACCESSORY_BLOCK_SIZE);
+
+  TEST_ASSERT_EQUAL(JOYBUS_CMD_N64_ACCESSORY_READ_RX, response_len);
+  TEST_ASSERT_EQUAL_HEX8_ARRAY(expected, response, JOYBUS_CMD_N64_ACCESSORY_READ_RX);
+}
+
+// Test that motor_start fires the callback once with active=true
+static void test_n64_rumble_pak_motor_start_fires_callback()
+{
+  joybus_n64_motor_start(&bus);
+
+  TEST_ASSERT_EQUAL(1, motor_callback_count);
+  TEST_ASSERT_TRUE(last_motor_state);
+  TEST_ASSERT_TRUE(rumble_pak.active);
+}
+
+// Test that motor_stop after motor_start fires the callback with active=false
+static void test_n64_rumble_pak_motor_stop_fires_callback_after_start()
+{
+  joybus_n64_motor_start(&bus);
+  joybus_n64_motor_stop(&bus);
+
+  TEST_ASSERT_EQUAL(2, motor_callback_count);
+  TEST_ASSERT_FALSE(last_motor_state);
+  TEST_ASSERT_FALSE(rumble_pak.active);
+}
+
+// Test that consecutive motor_start writes only fire the callback once (state unchanged)
+static void test_n64_rumble_pak_motor_callback_only_on_state_change()
+{
+  joybus_n64_motor_start(&bus);
+  joybus_n64_motor_start(&bus);
+  joybus_n64_motor_start(&bus);
+
+  TEST_ASSERT_EQUAL(1, motor_callback_count);
+}
+
+// Test that motor_stop with no prior start does not fire the callback (motor already off)
+static void test_n64_rumble_pak_motor_stop_when_already_off()
+{
+  joybus_n64_motor_stop(&bus);
+
+  TEST_ASSERT_EQUAL(0, motor_callback_count);
+  TEST_ASSERT_FALSE(rumble_pak.active);
+}
+
+// Test that motor writes are silently dropped when no callback is registered
+static void test_n64_rumble_pak_no_callback_set()
+{
+  joybus_n64_rumble_pak_set_motor_callback(&rumble_pak, NULL);
+
+  joybus_n64_motor_start(&bus);
+  joybus_n64_motor_stop(&bus);
+
+  // Internal state still updates, but no callback fires
+  TEST_ASSERT_EQUAL(0, motor_callback_count);
+  TEST_ASSERT_FALSE(rumble_pak.active);
+}
+
+// Test that writes to the probe region do not toggle the motor state
+static void test_n64_rumble_pak_write_outside_motor_region_ignored()
+{
+  uint8_t data[JOYBUS_ACCESSORY_BLOCK_SIZE];
+  memset(data, 0x01, sizeof(data));
+  joybus_n64_accessory_write(&bus, 0x8000, data, response, spy, NULL);
+
+  TEST_ASSERT_EQUAL(0, motor_callback_count);
+  TEST_ASSERT_FALSE(rumble_pak.active);
+}
+
+// Test that the host accessory detection routine identifies the pak as a rumble pak
+static void test_n64_rumble_pak_accessory_detect_identifies_rumble_pak()
+{
+  joybus_n64_accessory_detect(&bus, on_accessory_detected, NULL);
+
+  TEST_ASSERT_EQUAL(1, detect_callback_count);
+  TEST_ASSERT_EQUAL(JOYBUS_N64_ACCESSORY_RUMBLE_PAK, detected_accessory_type);
+}
+
+// Test that reads from outside the probe region return zeros
+static void test_n64_rumble_pak_read_outside_probe_region_returns_zeros()
+{
+  joybus_n64_accessory_read(&bus, 0x0000, response, spy, NULL);
+
+  uint8_t expected[JOYBUS_CMD_N64_ACCESSORY_READ_RX] = {0};
+  expected[JOYBUS_ACCESSORY_BLOCK_SIZE]              = joybus_crc8(expected, JOYBUS_ACCESSORY_BLOCK_SIZE);
+
+  TEST_ASSERT_EQUAL(JOYBUS_CMD_N64_ACCESSORY_READ_RX, response_len);
+  TEST_ASSERT_EQUAL_HEX8_ARRAY(expected, response, JOYBUS_CMD_N64_ACCESSORY_READ_RX);
+}
+
+int main(int argc, char **argv)
+{
+  UNITY_BEGIN();
+  RUN_TEST(test_n64_rumble_pak_probe_read_returns_signature);
+  RUN_TEST(test_n64_rumble_pak_detection_sequence);
+  RUN_TEST(test_n64_rumble_pak_motor_start_fires_callback);
+  RUN_TEST(test_n64_rumble_pak_motor_stop_fires_callback_after_start);
+  RUN_TEST(test_n64_rumble_pak_motor_callback_only_on_state_change);
+  RUN_TEST(test_n64_rumble_pak_motor_stop_when_already_off);
+  RUN_TEST(test_n64_rumble_pak_no_callback_set);
+  RUN_TEST(test_n64_rumble_pak_write_outside_motor_region_ignored);
+  RUN_TEST(test_n64_rumble_pak_read_outside_probe_region_returns_zeros);
+  RUN_TEST(test_n64_rumble_pak_accessory_detect_identifies_rumble_pak);
+
+  return UNITY_END();
+}

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -12,6 +12,7 @@ zephyr_library_sources(
   ${LIBJOYBUS_DIR}/src/host/n64.c
   ${LIBJOYBUS_DIR}/src/target/gc_controller.c
   ${LIBJOYBUS_DIR}/src/target/n64_controller.c
+  ${LIBJOYBUS_DIR}/src/target/n64_rumble_pak.c
 )
 
 # Specify the include paths


### PR DESCRIPTION
This PR adds support for N64 controller accessories, and includes a pre-built Rumble Pak accessory.