### PR TITLE
Explicit host/target modes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ static const struct joybus_api mybackend_api = {
   .transfer = joybus_mybackend_transfer,
 };
 
-int joybus_mybackend_init(struct joybus *bus, ..., enum joybus_mode mode)
+int joybus_mybackend_init(struct joybus *bus, enum joybus_mode mode, ...)
 {
   bus->api  = &mybackend_api;
   bus->mode = mode;

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,9 +15,10 @@ static const struct joybus_api mybackend_api = {
   .target_unregister = joybus_mybackend_target_unregister,
 };
 
-int joybus_mybackend_init(struct joybus *bus, ...)
+int joybus_mybackend_init(struct joybus *bus, ..., enum joybus_mode mode)
 {
-  bus->api    = &mybackend_api;
+  bus->api  = &mybackend_api;
+  bus->mode = mode;
 
   // Rest of initialization code...
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,10 +13,9 @@ static const struct joybus_api mybackend_api = {
   .transfer = joybus_mybackend_transfer,
 };
 
-int joybus_mybackend_init(struct joybus *bus, enum joybus_mode mode, ...)
+int joybus_mybackend_init(struct joybus *bus, ...)
 {
-  bus->api  = &mybackend_api;
-  bus->mode = mode;
+  bus->api = &mybackend_api;
 
   // Rest of initialization code...
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,11 +8,9 @@ Each backend is expected to implement a `joybus_backend_init(...)` function, and
 
 ```c
 static const struct joybus_api mybackend_api = {
-  .enable            = joybus_mybackend_enable,
-  .disable           = joybus_mybackend_disable,
-  .transfer          = joybus_mybackend_transfer,
-  .target_register   = joybus_mybackend_target_register,
-  .target_unregister = joybus_mybackend_target_unregister,
+  .enable   = joybus_mybackend_enable,
+  .disable  = joybus_mybackend_disable,
+  .transfer = joybus_mybackend_transfer,
 };
 
 int joybus_mybackend_init(struct joybus *bus, ..., enum joybus_mode mode)

--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ struct joybus_rp2xxx rp2xxx_bus;
 struct joybus *bus = JOYBUS(&rp2xxx_bus);
 
 int main() {
-  // Initialize the Joybus on a specific GPIO pin and PIO instance
-  joybus_rp2xxx_init(&rp2xxx_bus, JOYBUS_GPIO, pio0);
+  // Initialize the Joybus on a specific GPIO pin and PIO instance, as a host
+  joybus_rp2xxx_init(&rp2xxx_bus, JOYBUS_GPIO, pio0, JOYBUS_MODE_HOST);
 
   // ...your code here
 
@@ -81,8 +81,8 @@ void read_controller() {
 }
 
 void main() {
-  // Initialize the Joybus
-  joybus_rp2xxx_init(&rp2xxx_bus, MY_GPIO, pio0);
+  // Initialize the Joybus as a host
+  joybus_rp2xxx_init(&rp2xxx_bus, MY_GPIO, pio0, JOYBUS_MODE_HOST);
   joybus_enable(bus);
 
   // Read the controller state in a loop
@@ -109,13 +109,15 @@ struct joybus *bus = JOYBUS(&rp2xxx_bus);
 struct joybus_target_gcn_controller controller;
 
 void main() {
-  // Initialize and enable the Joybus
-  joybus_rp2xxx_init(&rp2xxx_bus, MY_GPIO, pio0);
-  joybus_enable(bus);
+  // Initialize the Joybus as a target
+  joybus_rp2xxx_init(&rp2xxx_bus, MY_GPIO, pio0, JOYBUS_MODE_TARGET);
 
   // Initialize a GameCube controller target and register it on the bus
   joybus_target_gcn_controller_init(&controller);
   joybus_target_register(bus, JOYBUS_TARGET(&controller));
+
+  // Enable the Joybus once the target is registered
+  joybus_enable(bus);
 
   // At this point the target will respond to commands from a connected console!
   // Modify the input state as needed, for example based on GPIO or ADC readings

--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ struct joybus_rp2xxx rp2xxx_bus;
 struct joybus *bus = JOYBUS(&rp2xxx_bus);
 
 int main() {
-  // Initialize the Joybus as a host, on a specific GPIO pin and PIO instance
-  joybus_rp2xxx_init(&rp2xxx_bus, JOYBUS_MODE_HOST, JOYBUS_GPIO, pio0);
+  // Initialize the Joybus on a specific GPIO pin and PIO instance
+  joybus_rp2xxx_init(&rp2xxx_bus, JOYBUS_GPIO, pio0);
 
   // ...your code here
 
@@ -81,9 +81,9 @@ void read_controller() {
 }
 
 void main() {
-  // Initialize the Joybus as a host
-  joybus_rp2xxx_init(&rp2xxx_bus, JOYBUS_MODE_HOST, MY_GPIO, pio0);
-  joybus_enable(bus);
+  // Initialize the Joybus and enable it as a host
+  joybus_rp2xxx_init(&rp2xxx_bus, MY_GPIO, pio0);
+  joybus_enable(bus, JOYBUS_MODE_HOST);
 
   // Read the controller state in a loop
   while (1) {
@@ -109,15 +109,15 @@ struct joybus *bus = JOYBUS(&rp2xxx_bus);
 struct joybus_target_gcn_controller controller;
 
 void main() {
-  // Initialize the Joybus as a target
-  joybus_rp2xxx_init(&rp2xxx_bus, JOYBUS_MODE_TARGET, MY_GPIO, pio0);
+  // Initialize the Joybus
+  joybus_rp2xxx_init(&rp2xxx_bus, MY_GPIO, pio0);
 
   // Initialize a GameCube controller target and register it on the bus
   joybus_target_gcn_controller_init(&controller);
   joybus_target_register(bus, JOYBUS_TARGET(&controller));
 
-  // Enable the Joybus once the target is registered
-  joybus_enable(bus);
+  // Enable the Joybus as a target once the target handler is registered
+  joybus_enable(bus, JOYBUS_MODE_TARGET);
 
   // At this point the target will respond to commands from a connected console!
   // Modify the input state as needed, for example based on GPIO or ADC readings

--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ struct joybus_rp2xxx rp2xxx_bus;
 struct joybus *bus = JOYBUS(&rp2xxx_bus);
 
 int main() {
-  // Initialize the Joybus on a specific GPIO pin and PIO instance, as a host
-  joybus_rp2xxx_init(&rp2xxx_bus, JOYBUS_GPIO, pio0, JOYBUS_MODE_HOST);
+  // Initialize the Joybus as a host, on a specific GPIO pin and PIO instance
+  joybus_rp2xxx_init(&rp2xxx_bus, JOYBUS_MODE_HOST, JOYBUS_GPIO, pio0);
 
   // ...your code here
 
@@ -82,7 +82,7 @@ void read_controller() {
 
 void main() {
   // Initialize the Joybus as a host
-  joybus_rp2xxx_init(&rp2xxx_bus, MY_GPIO, pio0, JOYBUS_MODE_HOST);
+  joybus_rp2xxx_init(&rp2xxx_bus, JOYBUS_MODE_HOST, MY_GPIO, pio0);
   joybus_enable(bus);
 
   // Read the controller state in a loop
@@ -110,7 +110,7 @@ struct joybus_target_gcn_controller controller;
 
 void main() {
   // Initialize the Joybus as a target
-  joybus_rp2xxx_init(&rp2xxx_bus, MY_GPIO, pio0, JOYBUS_MODE_TARGET);
+  joybus_rp2xxx_init(&rp2xxx_bus, JOYBUS_MODE_TARGET, MY_GPIO, pio0);
 
   // Initialize a GameCube controller target and register it on the bus
   joybus_target_gcn_controller_init(&controller);

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ void read_controller() {
 }
 
 void main() {
-  // Initialize the Joybus and enable it as a host
+  // Initialize the Joybus and enable it in host mode
   joybus_rp2xxx_init(&rp2xxx_bus, MY_GPIO, pio0);
   joybus_enable(bus, JOYBUS_MODE_HOST);
 
@@ -112,11 +112,11 @@ void main() {
   // Initialize the Joybus
   joybus_rp2xxx_init(&rp2xxx_bus, MY_GPIO, pio0);
 
-  // Initialize a GameCube controller target and register it on the bus
+  // Initialize a GameCube controller target and attach it to the bus
   joybus_target_gcn_controller_init(&controller);
-  joybus_target_register(bus, JOYBUS_TARGET(&controller));
+  joybus_attach_target(bus, JOYBUS_TARGET(&controller));
 
-  // Enable the Joybus as a target once the target handler is registered
+  // Enable the Joybus in target mode
   joybus_enable(bus, JOYBUS_MODE_TARGET);
 
   // At this point the target will respond to commands from a connected console!

--- a/examples/gecko/gcn-host/app.c
+++ b/examples/gecko/gcn-host/app.c
@@ -91,7 +91,7 @@ void app_init(void)
   GPIO_PinModeSet(LED_PORT, LED_PIN, gpioModePushPull, 0);
 
   // Initialize Joybus
-  joybus_gecko_init(&gecko_bus, JOYBUS_PORT, JOYBUS_PIN, JOYBUS_TIMER, JOYBUS_USART, JOYBUS_MODE_HOST);
+  joybus_gecko_init(&gecko_bus, JOYBUS_MODE_HOST, JOYBUS_PORT, JOYBUS_PIN, JOYBUS_TIMER, JOYBUS_USART);
   joybus_enable(bus);
 
   // Poll for Joybus data at regular intervals

--- a/examples/gecko/gcn-host/app.c
+++ b/examples/gecko/gcn-host/app.c
@@ -91,7 +91,7 @@ void app_init(void)
   GPIO_PinModeSet(LED_PORT, LED_PIN, gpioModePushPull, 0);
 
   // Initialize Joybus
-  joybus_gecko_init(&gecko_bus, JOYBUS_PORT, JOYBUS_PIN, JOYBUS_TIMER, JOYBUS_USART);
+  joybus_gecko_init(&gecko_bus, JOYBUS_PORT, JOYBUS_PIN, JOYBUS_TIMER, JOYBUS_USART, JOYBUS_MODE_HOST);
   joybus_enable(bus);
 
   // Poll for Joybus data at regular intervals

--- a/examples/gecko/gcn-host/app.c
+++ b/examples/gecko/gcn-host/app.c
@@ -91,8 +91,8 @@ void app_init(void)
   GPIO_PinModeSet(LED_PORT, LED_PIN, gpioModePushPull, 0);
 
   // Initialize Joybus
-  joybus_gecko_init(&gecko_bus, JOYBUS_MODE_HOST, JOYBUS_PORT, JOYBUS_PIN, JOYBUS_TIMER, JOYBUS_USART);
-  joybus_enable(bus);
+  joybus_gecko_init(&gecko_bus, JOYBUS_PORT, JOYBUS_PIN, JOYBUS_TIMER, JOYBUS_USART);
+  joybus_enable(bus, JOYBUS_MODE_HOST);
 
   // Poll for Joybus data at regular intervals
   sl_sleeptimer_init();

--- a/examples/gecko/gcn-target/app.c
+++ b/examples/gecko/gcn-target/app.c
@@ -28,7 +28,7 @@ void app_init(void)
   GPIO_PinModeSet(BTN_PORT, BTN_PIN, gpioModeInput, 1);
 
   // Initialize the Joybus in target mode
-  joybus_gecko_init(&gecko_bus, JOYBUS_DATA_PORT, JOYBUS_DATA_PIN, JOYBUS_TIMER, JOYBUS_USART, JOYBUS_MODE_TARGET);
+  joybus_gecko_init(&gecko_bus, JOYBUS_MODE_TARGET, JOYBUS_DATA_PORT, JOYBUS_DATA_PIN, JOYBUS_TIMER, JOYBUS_USART);
 
   // Initialize a GameCube controller target as a standard controller
   joybus_target_gcn_controller_init(&gcn_controller);

--- a/examples/gecko/gcn-target/app.c
+++ b/examples/gecko/gcn-target/app.c
@@ -27,15 +27,17 @@ void app_init(void)
   CMU_ClockEnable(cmuClock_GPIO, true);
   GPIO_PinModeSet(BTN_PORT, BTN_PIN, gpioModeInput, 1);
 
-  // Initialize the Joybus
-  joybus_gecko_init(&gecko_bus, JOYBUS_DATA_PORT, JOYBUS_DATA_PIN, JOYBUS_TIMER, JOYBUS_USART);
-  joybus_enable(bus);
+  // Initialize the Joybus in target mode
+  joybus_gecko_init(&gecko_bus, JOYBUS_DATA_PORT, JOYBUS_DATA_PIN, JOYBUS_TIMER, JOYBUS_USART, JOYBUS_MODE_TARGET);
 
   // Initialize a GameCube controller target as a standard controller
   joybus_target_gcn_controller_init(&gcn_controller);
 
   // Register the target on the bus
   joybus_target_register(bus, JOYBUS_TARGET(&gcn_controller));
+
+  // Enable the Joybus
+  joybus_enable(bus);
 }
 
 void app_process_action(void)

--- a/examples/gecko/gcn-target/app.c
+++ b/examples/gecko/gcn-target/app.c
@@ -27,8 +27,8 @@ void app_init(void)
   CMU_ClockEnable(cmuClock_GPIO, true);
   GPIO_PinModeSet(BTN_PORT, BTN_PIN, gpioModeInput, 1);
 
-  // Initialize the Joybus in target mode
-  joybus_gecko_init(&gecko_bus, JOYBUS_MODE_TARGET, JOYBUS_DATA_PORT, JOYBUS_DATA_PIN, JOYBUS_TIMER, JOYBUS_USART);
+  // Initialize the Joybus
+  joybus_gecko_init(&gecko_bus, JOYBUS_DATA_PORT, JOYBUS_DATA_PIN, JOYBUS_TIMER, JOYBUS_USART);
 
   // Initialize a GameCube controller target as a standard controller
   joybus_target_gcn_controller_init(&gcn_controller);
@@ -36,8 +36,8 @@ void app_init(void)
   // Register the target on the bus
   joybus_target_register(bus, JOYBUS_TARGET(&gcn_controller));
 
-  // Enable the Joybus
-  joybus_enable(bus);
+  // Enable the Joybus in target mode
+  joybus_enable(bus, JOYBUS_MODE_TARGET);
 }
 
 void app_process_action(void)

--- a/examples/gecko/gcn-target/app.c
+++ b/examples/gecko/gcn-target/app.c
@@ -33,8 +33,8 @@ void app_init(void)
   // Initialize a GameCube controller target as a standard controller
   joybus_target_gcn_controller_init(&gcn_controller);
 
-  // Register the target on the bus
-  joybus_target_register(bus, JOYBUS_TARGET(&gcn_controller));
+  // Attach the target to the bus
+  joybus_attach_target(bus, JOYBUS_TARGET(&gcn_controller));
 
   // Enable the Joybus in target mode
   joybus_enable(bus, JOYBUS_MODE_TARGET);

--- a/examples/pico-sdk/gcn-adapter-nintendo/main.c
+++ b/examples/pico-sdk/gcn-adapter-nintendo/main.c
@@ -310,7 +310,7 @@ int main(void)
 
   // Initialize Joybus channels
   for (int i = 0; i < GCCA_JOYBUS_CHANNELS; i++) {
-    joybus_rp2xxx_init(&rp2xxx_bus[i], JOYBUS_GPIOS[i], pio0, JOYBUS_MODE_HOST);
+    joybus_rp2xxx_init(&rp2xxx_bus[i], JOYBUS_MODE_HOST, JOYBUS_GPIOS[i], pio0);
     joybus_enable(JOYBUS(&rp2xxx_bus[i]));
 
     reset_bus_state(i);

--- a/examples/pico-sdk/gcn-adapter-nintendo/main.c
+++ b/examples/pico-sdk/gcn-adapter-nintendo/main.c
@@ -310,8 +310,8 @@ int main(void)
 
   // Initialize Joybus channels
   for (int i = 0; i < GCCA_JOYBUS_CHANNELS; i++) {
-    joybus_rp2xxx_init(&rp2xxx_bus[i], JOYBUS_MODE_HOST, JOYBUS_GPIOS[i], pio0);
-    joybus_enable(JOYBUS(&rp2xxx_bus[i]));
+    joybus_rp2xxx_init(&rp2xxx_bus[i], JOYBUS_GPIOS[i], pio0);
+    joybus_enable(JOYBUS(&rp2xxx_bus[i]), JOYBUS_MODE_HOST);
 
     reset_bus_state(i);
   }

--- a/examples/pico-sdk/gcn-adapter-nintendo/main.c
+++ b/examples/pico-sdk/gcn-adapter-nintendo/main.c
@@ -310,7 +310,7 @@ int main(void)
 
   // Initialize Joybus channels
   for (int i = 0; i < GCCA_JOYBUS_CHANNELS; i++) {
-    joybus_rp2xxx_init(&rp2xxx_bus[i], JOYBUS_GPIOS[i], pio0);
+    joybus_rp2xxx_init(&rp2xxx_bus[i], JOYBUS_GPIOS[i], pio0, JOYBUS_MODE_HOST);
     joybus_enable(JOYBUS(&rp2xxx_bus[i]));
 
     reset_bus_state(i);

--- a/examples/pico-sdk/gcn-adapter-usb-hid/main.c
+++ b/examples/pico-sdk/gcn-adapter-usb-hid/main.c
@@ -193,7 +193,7 @@ int main(void)
   tusb_init();
 
   // Initialize Joybus
-  joybus_rp2xxx_init(&rp2xxx_bus, JOYBUS_GPIO, pio0);
+  joybus_rp2xxx_init(&rp2xxx_bus, JOYBUS_GPIO, pio0, JOYBUS_MODE_HOST);
   joybus_enable(bus);
 
   // Poll for Joybus data and send HID reports at regular intervals

--- a/examples/pico-sdk/gcn-adapter-usb-hid/main.c
+++ b/examples/pico-sdk/gcn-adapter-usb-hid/main.c
@@ -193,7 +193,7 @@ int main(void)
   tusb_init();
 
   // Initialize Joybus
-  joybus_rp2xxx_init(&rp2xxx_bus, JOYBUS_GPIO, pio0, JOYBUS_MODE_HOST);
+  joybus_rp2xxx_init(&rp2xxx_bus, JOYBUS_MODE_HOST, JOYBUS_GPIO, pio0);
   joybus_enable(bus);
 
   // Poll for Joybus data and send HID reports at regular intervals

--- a/examples/pico-sdk/gcn-adapter-usb-hid/main.c
+++ b/examples/pico-sdk/gcn-adapter-usb-hid/main.c
@@ -193,8 +193,8 @@ int main(void)
   tusb_init();
 
   // Initialize Joybus
-  joybus_rp2xxx_init(&rp2xxx_bus, JOYBUS_MODE_HOST, JOYBUS_GPIO, pio0);
-  joybus_enable(bus);
+  joybus_rp2xxx_init(&rp2xxx_bus, JOYBUS_GPIO, pio0);
+  joybus_enable(bus, JOYBUS_MODE_HOST);
 
   // Poll for Joybus data and send HID reports at regular intervals
   struct repeating_timer poll_timer;

--- a/examples/pico-sdk/gcn-host/main.c
+++ b/examples/pico-sdk/gcn-host/main.c
@@ -88,8 +88,8 @@ int main()
   gpio_put(LED_GPIO, 0);
 
   // Initialize Joybus
-  joybus_rp2xxx_init(&rp2xxx_bus, JOYBUS_MODE_HOST, JOYBUS_GPIO, pio0);
-  joybus_enable(bus);
+  joybus_rp2xxx_init(&rp2xxx_bus, JOYBUS_GPIO, pio0);
+  joybus_enable(bus, JOYBUS_MODE_HOST);
 
   // Poll for Joybus data at regular intervals
   struct repeating_timer poll_timer;

--- a/examples/pico-sdk/gcn-host/main.c
+++ b/examples/pico-sdk/gcn-host/main.c
@@ -88,7 +88,7 @@ int main()
   gpio_put(LED_GPIO, 0);
 
   // Initialize Joybus
-  joybus_rp2xxx_init(&rp2xxx_bus, JOYBUS_GPIO, pio0, JOYBUS_MODE_HOST);
+  joybus_rp2xxx_init(&rp2xxx_bus, JOYBUS_MODE_HOST, JOYBUS_GPIO, pio0);
   joybus_enable(bus);
 
   // Poll for Joybus data at regular intervals

--- a/examples/pico-sdk/gcn-host/main.c
+++ b/examples/pico-sdk/gcn-host/main.c
@@ -88,7 +88,7 @@ int main()
   gpio_put(LED_GPIO, 0);
 
   // Initialize Joybus
-  joybus_rp2xxx_init(&rp2xxx_bus, JOYBUS_GPIO, pio0);
+  joybus_rp2xxx_init(&rp2xxx_bus, JOYBUS_GPIO, pio0, JOYBUS_MODE_HOST);
   joybus_enable(bus);
 
   // Poll for Joybus data at regular intervals

--- a/examples/pico-sdk/gcn-target/main.c
+++ b/examples/pico-sdk/gcn-target/main.c
@@ -20,7 +20,7 @@ int main()
   gpio_pull_up(BUTTON_A_GPIO);
 
   // Initialize the Joybus in target mode
-  joybus_rp2xxx_init(&rp2xxx_bus, JOYBUS_GPIO, pio0, JOYBUS_MODE_TARGET);
+  joybus_rp2xxx_init(&rp2xxx_bus, JOYBUS_MODE_TARGET, JOYBUS_GPIO, pio0);
 
   // Initialize a GameCube controller target as a standard controller
   joybus_target_gcn_controller_init(&gcn_controller);

--- a/examples/pico-sdk/gcn-target/main.c
+++ b/examples/pico-sdk/gcn-target/main.c
@@ -19,15 +19,17 @@ int main()
   gpio_init(BUTTON_A_GPIO);
   gpio_pull_up(BUTTON_A_GPIO);
 
-  // Initialize the Joybus
-  joybus_rp2xxx_init(&rp2xxx_bus, JOYBUS_GPIO, pio0);
-  joybus_enable(bus);
+  // Initialize the Joybus in target mode
+  joybus_rp2xxx_init(&rp2xxx_bus, JOYBUS_GPIO, pio0, JOYBUS_MODE_TARGET);
 
   // Initialize a GameCube controller target as a standard controller
   joybus_target_gcn_controller_init(&gcn_controller);
 
   // Register the target on the bus
   joybus_target_register(bus, JOYBUS_TARGET(&gcn_controller));
+
+  // Enable the Joybus
+  joybus_enable(bus);
 
   while (1) {
     // Clear previous button state

--- a/examples/pico-sdk/gcn-target/main.c
+++ b/examples/pico-sdk/gcn-target/main.c
@@ -25,8 +25,8 @@ int main()
   // Initialize a GameCube controller target as a standard controller
   joybus_target_gcn_controller_init(&gcn_controller);
 
-  // Register the target on the bus
-  joybus_target_register(bus, JOYBUS_TARGET(&gcn_controller));
+  // Attach the target to the bus
+  joybus_attach_target(bus, JOYBUS_TARGET(&gcn_controller));
 
   // Enable the Joybus in target mode
   joybus_enable(bus, JOYBUS_MODE_TARGET);

--- a/examples/pico-sdk/gcn-target/main.c
+++ b/examples/pico-sdk/gcn-target/main.c
@@ -19,8 +19,8 @@ int main()
   gpio_init(BUTTON_A_GPIO);
   gpio_pull_up(BUTTON_A_GPIO);
 
-  // Initialize the Joybus in target mode
-  joybus_rp2xxx_init(&rp2xxx_bus, JOYBUS_MODE_TARGET, JOYBUS_GPIO, pio0);
+  // Initialize the Joybus
+  joybus_rp2xxx_init(&rp2xxx_bus, JOYBUS_GPIO, pio0);
 
   // Initialize a GameCube controller target as a standard controller
   joybus_target_gcn_controller_init(&gcn_controller);
@@ -28,8 +28,8 @@ int main()
   // Register the target on the bus
   joybus_target_register(bus, JOYBUS_TARGET(&gcn_controller));
 
-  // Enable the Joybus
-  joybus_enable(bus);
+  // Enable the Joybus in target mode
+  joybus_enable(bus, JOYBUS_MODE_TARGET);
 
   while (1) {
     // Clear previous button state

--- a/examples/pico-sdk/n64-adapter-usb-hid/main.c
+++ b/examples/pico-sdk/n64-adapter-usb-hid/main.c
@@ -145,7 +145,7 @@ int main(void)
   tusb_init();
 
   // Initialize Joybus
-  joybus_rp2xxx_init(&rp2xxx_bus, JOYBUS_GPIO, pio0);
+  joybus_rp2xxx_init(&rp2xxx_bus, JOYBUS_GPIO, pio0, JOYBUS_MODE_HOST);
   joybus_enable(bus);
 
   // Poll for Joybus data and send HID reports at regular intervals

--- a/examples/pico-sdk/n64-adapter-usb-hid/main.c
+++ b/examples/pico-sdk/n64-adapter-usb-hid/main.c
@@ -145,8 +145,8 @@ int main(void)
   tusb_init();
 
   // Initialize Joybus
-  joybus_rp2xxx_init(&rp2xxx_bus, JOYBUS_MODE_HOST, JOYBUS_GPIO, pio0);
-  joybus_enable(bus);
+  joybus_rp2xxx_init(&rp2xxx_bus, JOYBUS_GPIO, pio0);
+  joybus_enable(bus, JOYBUS_MODE_HOST);
 
   // Poll for Joybus data and send HID reports at regular intervals
   struct repeating_timer poll_timer;

--- a/examples/pico-sdk/n64-adapter-usb-hid/main.c
+++ b/examples/pico-sdk/n64-adapter-usb-hid/main.c
@@ -145,7 +145,7 @@ int main(void)
   tusb_init();
 
   // Initialize Joybus
-  joybus_rp2xxx_init(&rp2xxx_bus, JOYBUS_GPIO, pio0, JOYBUS_MODE_HOST);
+  joybus_rp2xxx_init(&rp2xxx_bus, JOYBUS_MODE_HOST, JOYBUS_GPIO, pio0);
   joybus_enable(bus);
 
   // Poll for Joybus data and send HID reports at regular intervals

--- a/examples/pico-sdk/n64-host/main.c
+++ b/examples/pico-sdk/n64-host/main.c
@@ -80,7 +80,7 @@ int main()
   gpio_put(LED_GPIO, 0);
 
   // Initialize Joybus
-  joybus_rp2xxx_init(&rp2xxx_bus, JOYBUS_GPIO, pio0);
+  joybus_rp2xxx_init(&rp2xxx_bus, JOYBUS_GPIO, pio0, JOYBUS_MODE_HOST);
   joybus_enable(bus);
 
   // Poll the controller once per "frame"

--- a/examples/pico-sdk/n64-host/main.c
+++ b/examples/pico-sdk/n64-host/main.c
@@ -80,8 +80,8 @@ int main()
   gpio_put(LED_GPIO, 0);
 
   // Initialize Joybus
-  joybus_rp2xxx_init(&rp2xxx_bus, JOYBUS_MODE_HOST, JOYBUS_GPIO, pio0);
-  joybus_enable(bus);
+  joybus_rp2xxx_init(&rp2xxx_bus, JOYBUS_GPIO, pio0);
+  joybus_enable(bus, JOYBUS_MODE_HOST);
 
   // Poll the controller once per "frame"
   absolute_time_t next_frame = get_absolute_time();

--- a/examples/pico-sdk/n64-host/main.c
+++ b/examples/pico-sdk/n64-host/main.c
@@ -80,7 +80,7 @@ int main()
   gpio_put(LED_GPIO, 0);
 
   // Initialize Joybus
-  joybus_rp2xxx_init(&rp2xxx_bus, JOYBUS_GPIO, pio0, JOYBUS_MODE_HOST);
+  joybus_rp2xxx_init(&rp2xxx_bus, JOYBUS_MODE_HOST, JOYBUS_GPIO, pio0);
   joybus_enable(bus);
 
   // Poll the controller once per "frame"

--- a/examples/pico-sdk/n64-target/main.c
+++ b/examples/pico-sdk/n64-target/main.c
@@ -53,8 +53,8 @@ static int8_t read_stick_axis(uint gpio, int origin, bool inverted)
 
 int main()
 {
-  // Initialize the Joybus in target mode
-  joybus_rp2xxx_init(&rp2xxx_bus, JOYBUS_MODE_TARGET, JOYBUS_GPIO, pio0);
+  // Initialize the Joybus
+  joybus_rp2xxx_init(&rp2xxx_bus, JOYBUS_GPIO, pio0);
 
   // Initialize a N64 controller target as a standard controller
   joybus_target_n64_controller_init(&n64_controller);
@@ -62,8 +62,8 @@ int main()
   // Register the target on the bus
   joybus_target_register(bus, JOYBUS_TARGET(&n64_controller));
 
-  // Enable the Joybus
-  joybus_enable(bus);
+  // Enable the Joybus in target mode
+  joybus_enable(bus, JOYBUS_MODE_TARGET);
 
   // Configure button GPIOs as input with pull-up (active low)
   for (size_t i = 0; i < sizeof(button_map) / sizeof(button_map[0]); i++) {

--- a/examples/pico-sdk/n64-target/main.c
+++ b/examples/pico-sdk/n64-target/main.c
@@ -54,7 +54,7 @@ static int8_t read_stick_axis(uint gpio, int origin, bool inverted)
 int main()
 {
   // Initialize the Joybus in target mode
-  joybus_rp2xxx_init(&rp2xxx_bus, JOYBUS_GPIO, pio0, JOYBUS_MODE_TARGET);
+  joybus_rp2xxx_init(&rp2xxx_bus, JOYBUS_MODE_TARGET, JOYBUS_GPIO, pio0);
 
   // Initialize a N64 controller target as a standard controller
   joybus_target_n64_controller_init(&n64_controller);

--- a/examples/pico-sdk/n64-target/main.c
+++ b/examples/pico-sdk/n64-target/main.c
@@ -59,8 +59,8 @@ int main()
   // Initialize a N64 controller target as a standard controller
   joybus_target_n64_controller_init(&n64_controller);
 
-  // Register the target on the bus
-  joybus_target_register(bus, JOYBUS_TARGET(&n64_controller));
+  // Attach the target to the bus
+  joybus_attach_target(bus, JOYBUS_TARGET(&n64_controller));
 
   // Enable the Joybus in target mode
   joybus_enable(bus, JOYBUS_MODE_TARGET);

--- a/examples/pico-sdk/n64-target/main.c
+++ b/examples/pico-sdk/n64-target/main.c
@@ -53,15 +53,17 @@ static int8_t read_stick_axis(uint gpio, int origin, bool inverted)
 
 int main()
 {
-  // Initialize the Joybus
-  joybus_rp2xxx_init(&rp2xxx_bus, JOYBUS_GPIO, pio0);
-  joybus_enable(bus);
+  // Initialize the Joybus in target mode
+  joybus_rp2xxx_init(&rp2xxx_bus, JOYBUS_GPIO, pio0, JOYBUS_MODE_TARGET);
 
   // Initialize a N64 controller target as a standard controller
   joybus_target_n64_controller_init(&n64_controller);
 
   // Register the target on the bus
   joybus_target_register(bus, JOYBUS_TARGET(&n64_controller));
+
+  // Enable the Joybus
+  joybus_enable(bus);
 
   // Configure button GPIOs as input with pull-up (active low)
   for (size_t i = 0; i < sizeof(button_map) / sizeof(button_map[0]); i++) {

--- a/include/joybus/backend/gecko.h
+++ b/include/joybus/backend/gecko.h
@@ -96,14 +96,14 @@ struct joybus_gecko {
  * Routing Table in the reference manual for your MCU.
  *
  * @param gecko_bus the Gecko Joybus instance to initialize
+ * @param mode whether this instance acts as a host or a target
  * @param port the GPIO port to use for the Joybus data line
  * @param pin the GPIO pin to use for the Joybus data line
  * @param rx_timer the TIMER peripheral to use for receiving data
  * @param tx_usart the USART peripheral to use for transmitting data
- * @param mode whether this instance acts as a host or a target
  * @return 0 on success, a negative joybus_error on failure
  */
-int joybus_gecko_init(struct joybus_gecko *gecko_bus, GPIO_Port_TypeDef port, uint8_t pin, TIMER_TypeDef *rx_timer,
-                      USART_TypeDef *tx_usart, enum joybus_mode mode);
+int joybus_gecko_init(struct joybus_gecko *gecko_bus, enum joybus_mode mode, GPIO_Port_TypeDef port, uint8_t pin,
+                      TIMER_TypeDef *rx_timer, USART_TypeDef *tx_usart);
 
 /** @} */

--- a/include/joybus/backend/gecko.h
+++ b/include/joybus/backend/gecko.h
@@ -96,14 +96,13 @@ struct joybus_gecko {
  * Routing Table in the reference manual for your MCU.
  *
  * @param gecko_bus the Gecko Joybus instance to initialize
- * @param mode whether this instance acts as a host or a target
  * @param port the GPIO port to use for the Joybus data line
  * @param pin the GPIO pin to use for the Joybus data line
  * @param rx_timer the TIMER peripheral to use for receiving data
  * @param tx_usart the USART peripheral to use for transmitting data
  * @return 0 on success, a negative joybus_error on failure
  */
-int joybus_gecko_init(struct joybus_gecko *gecko_bus, enum joybus_mode mode, GPIO_Port_TypeDef port, uint8_t pin,
-                      TIMER_TypeDef *rx_timer, USART_TypeDef *tx_usart);
+int joybus_gecko_init(struct joybus_gecko *gecko_bus, GPIO_Port_TypeDef port, uint8_t pin, TIMER_TypeDef *rx_timer,
+                      USART_TypeDef *tx_usart);
 
 /** @} */

--- a/include/joybus/backend/gecko.h
+++ b/include/joybus/backend/gecko.h
@@ -100,9 +100,10 @@ struct joybus_gecko {
  * @param pin the GPIO pin to use for the Joybus data line
  * @param rx_timer the TIMER peripheral to use for receiving data
  * @param tx_usart the USART peripheral to use for transmitting data
+ * @param mode whether this instance acts as a host or a target
  * @return 0 on success, a negative joybus_error on failure
  */
 int joybus_gecko_init(struct joybus_gecko *gecko_bus, GPIO_Port_TypeDef port, uint8_t pin, TIMER_TypeDef *rx_timer,
-                      USART_TypeDef *tx_usart);
+                      USART_TypeDef *tx_usart, enum joybus_mode mode);
 
 /** @} */

--- a/include/joybus/backend/rp2xxx.h
+++ b/include/joybus/backend/rp2xxx.h
@@ -34,7 +34,7 @@ struct joybus_rp2xxx_data {
   // PIO instance and state machine
   PIO pio;
   uint pio_sm;
-  uint8_t pio_sm_mode;
+  bool pio_configured;
 
   // DMA configuration
   uint dma_chan_tx;
@@ -67,11 +67,11 @@ struct joybus_rp2xxx {
  * Initialize a RP2xxx Joybus instance.
  *
  * @param rp2xxx_bus the RP2xxx Joybus instance to initialize
+ * @param mode whether this instance acts as a host or a target
  * @param gpio the GPIO pin to use for the Joybus data line
  * @param pio the PIO instance to use (eg. pio0 or pio1)
- * @param mode whether this instance acts as a host or a target
  * @return 0 on success, a negative joybus_error on failure
  */
-int joybus_rp2xxx_init(struct joybus_rp2xxx *rp2xxx_bus, uint8_t gpio, PIO pio, enum joybus_mode mode);
+int joybus_rp2xxx_init(struct joybus_rp2xxx *rp2xxx_bus, enum joybus_mode mode, uint8_t gpio, PIO pio);
 
 /** @} */

--- a/include/joybus/backend/rp2xxx.h
+++ b/include/joybus/backend/rp2xxx.h
@@ -67,11 +67,10 @@ struct joybus_rp2xxx {
  * Initialize a RP2xxx Joybus instance.
  *
  * @param rp2xxx_bus the RP2xxx Joybus instance to initialize
- * @param mode whether this instance acts as a host or a target
  * @param gpio the GPIO pin to use for the Joybus data line
  * @param pio the PIO instance to use (eg. pio0 or pio1)
  * @return 0 on success, a negative joybus_error on failure
  */
-int joybus_rp2xxx_init(struct joybus_rp2xxx *rp2xxx_bus, enum joybus_mode mode, uint8_t gpio, PIO pio);
+int joybus_rp2xxx_init(struct joybus_rp2xxx *rp2xxx_bus, uint8_t gpio, PIO pio);
 
 /** @} */

--- a/include/joybus/backend/rp2xxx.h
+++ b/include/joybus/backend/rp2xxx.h
@@ -69,8 +69,9 @@ struct joybus_rp2xxx {
  * @param rp2xxx_bus the RP2xxx Joybus instance to initialize
  * @param gpio the GPIO pin to use for the Joybus data line
  * @param pio the PIO instance to use (eg. pio0 or pio1)
+ * @param mode whether this instance acts as a host or a target
  * @return 0 on success, a negative joybus_error on failure
  */
-int joybus_rp2xxx_init(struct joybus_rp2xxx *rp2xxx_bus, uint8_t gpio, PIO pio);
+int joybus_rp2xxx_init(struct joybus_rp2xxx *rp2xxx_bus, uint8_t gpio, PIO pio, enum joybus_mode mode);
 
 /** @} */

--- a/include/joybus/bus.h
+++ b/include/joybus/bus.h
@@ -62,9 +62,6 @@ struct joybus;
 
 /**
  * The role a Joybus instance plays on the bus.
- *
- * Fixed when the instance is initialized. A host drives the bus and polls
- * devices, a target responds to commands from a host.
  */
 enum joybus_mode {
   JOYBUS_MODE_HOST,

--- a/include/joybus/bus.h
+++ b/include/joybus/bus.h
@@ -110,12 +110,18 @@ struct joybus {
 };
 
 /**
- * Enable the Joybus instance.
+ * Enable the Joybus instance in the given mode.
+ *
+ * Spins up the backend peripherals and starts operating as a host or a target.
+ * The mode applies until the instance is disabled; to switch modes, disable the
+ * instance and enable it again with the other mode.
  *
  * @param bus the Joybus instance to enable
+ * @param mode whether to operate as a host or a target
  */
-static inline int joybus_enable(struct joybus *bus)
+static inline int joybus_enable(struct joybus *bus, enum joybus_mode mode)
 {
+  bus->mode = mode;
   return bus->api->enable(bus);
 }
 

--- a/include/joybus/bus.h
+++ b/include/joybus/bus.h
@@ -61,6 +61,17 @@ struct joybus;
 #define JOYBUS(bus) ((struct joybus *)(bus))
 
 /**
+ * The role a Joybus instance plays on the bus.
+ *
+ * Fixed when the instance is initialized. A host drives the bus and polls
+ * devices, a target responds to commands from a host.
+ */
+enum joybus_mode {
+  JOYBUS_MODE_HOST,
+  JOYBUS_MODE_TARGET,
+};
+
+/**
  * Function type for transfer completion callbacks.
  *
  * Invoked once, after the async call has returned, when a started transfer
@@ -96,6 +107,7 @@ struct joybus_host_op {
 struct joybus {
   const struct joybus_api *api;
 
+  enum joybus_mode mode;
   struct joybus_target *target;
   uint8_t command_buffer[JOYBUS_BLOCK_SIZE];
   uint8_t response_buffer[JOYBUS_BLOCK_SIZE];

--- a/include/joybus/bus.h
+++ b/include/joybus/bus.h
@@ -176,31 +176,31 @@ int joybus_transfer_sync(struct joybus *bus, const uint8_t *write_buf, uint8_t w
                          uint8_t read_len);
 
 /**
- * Register a target to handle commands received in target mode.
+ * Attach a target to handle commands received in target mode.
  *
  * @param bus the Joybus instance to use
- * @param target the target to register
+ * @param target the target to attach
  * @return 0 on success, a negative joybus_error on failure
  */
-static inline int joybus_target_register(struct joybus *bus, struct joybus_target *target)
+static inline int joybus_attach_target(struct joybus *bus, struct joybus_target *target)
 {
-  bus->target        = target;
-  target->registered = true;
+  bus->target      = target;
+  target->attached = true;
 
   return 0;
 }
 
 /**
- * Unregister a Joybus target.
+ * Detach a target from the bus.
  *
  * @param bus the Joybus instance to use
- * @param target the target to unregister
+ * @param target the target to detach
  * @return 0 on success, a negative joybus_error on failure
  */
-static inline int joybus_target_unregister(struct joybus *bus, struct joybus_target *target)
+static inline int joybus_detach_target(struct joybus *bus, struct joybus_target *target)
 {
-  bus->target        = NULL;
-  target->registered = false;
+  bus->target      = NULL;
+  target->attached = false;
 
   return 0;
 }

--- a/include/joybus/bus.h
+++ b/include/joybus/bus.h
@@ -90,8 +90,6 @@ struct joybus_api {
   int (*disable)(struct joybus *bus);
   int (*transfer)(struct joybus *bus, const uint8_t *write_buf, uint8_t write_len, uint8_t *read_buf, uint8_t read_len,
                   joybus_transfer_cb callback, void *user_data);
-  int (*target_register)(struct joybus *bus, struct joybus_target *target);
-  int (*target_unregister)(struct joybus *bus, struct joybus_target *target);
 };
 
 struct joybus_host_op {
@@ -175,7 +173,7 @@ int joybus_transfer_sync(struct joybus *bus, const uint8_t *write_buf, uint8_t w
                          uint8_t read_len);
 
 /**
- * Enable Joybus "target" mode, and register a target to handle commands.
+ * Register a target to handle commands received in target mode.
  *
  * @param bus the Joybus instance to use
  * @param target the target to register
@@ -183,12 +181,10 @@ int joybus_transfer_sync(struct joybus *bus, const uint8_t *write_buf, uint8_t w
  */
 static inline int joybus_target_register(struct joybus *bus, struct joybus_target *target)
 {
-  // Common setup
   bus->target        = target;
   target->registered = true;
 
-  // Backend-specific registration
-  return bus->api->target_register(bus, target);
+  return 0;
 }
 
 /**
@@ -200,14 +196,10 @@ static inline int joybus_target_register(struct joybus *bus, struct joybus_targe
  */
 static inline int joybus_target_unregister(struct joybus *bus, struct joybus_target *target)
 {
-  // Backend-specific unregistration
-  int status = bus->api->target_unregister(bus, target);
-
-  // Common teardown
   bus->target        = NULL;
   target->registered = false;
 
-  return status;
+  return 0;
 }
 
 // Context for a blocking Joybus operation

--- a/include/joybus/target.h
+++ b/include/joybus/target.h
@@ -31,6 +31,8 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#include <joybus/errors.h>
+
 struct joybus_target;
 
 /// Macro to cast a concrete Joybus target instance to a generic Joybus target instance.
@@ -87,6 +89,10 @@ struct joybus_target {
 static inline int joybus_target_byte_received(struct joybus_target *target, const uint8_t *command, uint8_t byte_idx,
                                               joybus_target_response_cb send_response, void *user_data)
 {
+  // No target registered to handle the command
+  if (!target)
+    return -JOYBUS_ERR_NOT_SUPPORTED;
+
   return target->api->byte_received(target, command, byte_idx, send_response, user_data);
 }
 

--- a/include/joybus/target.h
+++ b/include/joybus/target.h
@@ -20,8 +20,8 @@
  *
  * To create your own target, define a struct whose first member is a
  * ::joybus_target (so it can be cast through ::JOYBUS_TARGET), point its api
- * at a ::joybus_target_api table, and register it on a bus with
- * joybus_target_register().
+ * at a ::joybus_target_api table, and attach it to a bus with
+ * joybus_attach_target().
  *
  * @{
  */
@@ -72,8 +72,8 @@ struct joybus_target {
   /// API for handling received commands
   const struct joybus_target_api *api;
 
-  /// Whether the target is currently registered on the bus
-  bool registered;
+  /// Whether the target is currently attached to a bus
+  bool attached;
 };
 
 /**
@@ -89,7 +89,7 @@ struct joybus_target {
 static inline int joybus_target_byte_received(struct joybus_target *target, const uint8_t *command, uint8_t byte_idx,
                                               joybus_target_response_cb send_response, void *user_data)
 {
-  // No target registered to handle the command
+  // No target attached to handle the command
   if (!target)
     return -JOYBUS_ERR_NOT_SUPPORTED;
 
@@ -97,14 +97,14 @@ static inline int joybus_target_byte_received(struct joybus_target *target, cons
 }
 
 /**
- * Check if a target is currently registered on the bus.
+ * Check if a target is currently attached to a bus.
  *
  * @param target the target to check
- * @return true if the target is registered, false otherwise
+ * @return true if the target is attached, false otherwise
  */
-static inline bool joybus_target_is_registered(struct joybus_target *target)
+static inline bool joybus_target_is_attached(struct joybus_target *target)
 {
-  return target->registered;
+  return target->attached;
 }
 
 /** @} */

--- a/src/backend/gecko_sdk/joybus.c
+++ b/src/backend/gecko_sdk/joybus.c
@@ -481,7 +481,7 @@ static inline void prepare_write(struct joybus *bus, const uint8_t *buffer, uint
                            ldma_tx_handler, bus);
 }
 
-// Callback for handling a command response from the registered target
+// Callback for handling a command response from the attached target
 static void handle_command_response(const uint8_t *buffer, uint8_t length, void *user_data)
 {
   struct joybus *bus = (struct joybus *)user_data;

--- a/src/backend/gecko_sdk/joybus.c
+++ b/src/backend/gecko_sdk/joybus.c
@@ -710,12 +710,11 @@ static const struct joybus_api gecko_api = {
   .transfer = joybus_gecko_transfer,
 };
 
-int joybus_gecko_init(struct joybus_gecko *gecko_bus, enum joybus_mode mode, GPIO_Port_TypeDef port, uint8_t pin,
-                      TIMER_TypeDef *rx_timer, USART_TypeDef *tx_usart)
+int joybus_gecko_init(struct joybus_gecko *gecko_bus, GPIO_Port_TypeDef port, uint8_t pin, TIMER_TypeDef *rx_timer,
+                      USART_TypeDef *tx_usart)
 {
   struct joybus *bus = JOYBUS(gecko_bus);
   bus->api           = &gecko_api;
-  bus->mode          = mode;
   bus->target        = NULL;
 
   // Save the joybus configuration

--- a/src/backend/gecko_sdk/joybus.c
+++ b/src/backend/gecko_sdk/joybus.c
@@ -46,6 +46,7 @@ static const uint8_t HOST_STOP   = 0b01111111;
 static const uint8_t TARGET_STOP = 0b00111111;
 
 static void enter_target_read_mode(struct joybus *bus, bool await_idle);
+static void enter_idle_mode(struct joybus *bus, bool await_idle);
 static void handle_command_response(const uint8_t *buffer, uint8_t length, void *user_data);
 static bool ldma_tx_handler(unsigned int chan, unsigned int iteration, void *user_data);
 
@@ -237,11 +238,7 @@ void transfer_timeout(sl_sleeptimer_timer_handle_t *handle, void *user_data)
   struct joybus_gecko_data *data = &JOYBUS_GECKO(bus)->data;
 
   // Timeout occurred, switch back to idle/read mode
-  if (bus->mode == JOYBUS_MODE_TARGET) {
-    enter_target_read_mode(bus, true);
-  } else {
-    data->state = BUS_STATE_HOST_IDLE;
-  }
+  enter_idle_mode(bus, true);
 
   // Call the transfer complete callback with an error
   if (data->done_callback)
@@ -255,11 +252,7 @@ void target_rx_timeout(sl_sleeptimer_timer_handle_t *handle, void *user_data)
   struct joybus_gecko_data *data = &JOYBUS_GECKO(bus)->data;
 
   // Timeout occurred, switch back to idle/read mode
-  if (bus->mode == JOYBUS_MODE_TARGET) {
-    enter_target_read_mode(bus, true);
-  } else {
-    data->state = BUS_STATE_HOST_IDLE;
-  }
+  enter_idle_mode(bus, true);
 }
 
 static inline uint32_t sl_sleeptimer_us_to_tick(uint32_t time_us)
@@ -288,11 +281,7 @@ static bool ldma_rx_handler(unsigned int chan, unsigned int iteration, void *use
       TIMER_Enable(data->rx_timer, false);
 
       // Switch back to idle/read mode
-      if (bus->mode == JOYBUS_MODE_TARGET) {
-        enter_target_read_mode(bus, true);
-      } else {
-        data->state = BUS_STATE_HOST_IDLE;
-      }
+      enter_idle_mode(bus, true);
 
       // Call the transfer complete callback with a success status
       if (data->done_callback)
@@ -337,11 +326,7 @@ static bool ldma_rx_handler(unsigned int chan, unsigned int iteration, void *use
         TIMER_Enable(data->rx_timer, false);
 
         // No response to send, switch back to read mode or idle
-        if (bus->mode == JOYBUS_MODE_TARGET) {
-          enter_target_read_mode(bus, false);
-        } else {
-          data->state = BUS_STATE_HOST_IDLE;
-        }
+        enter_idle_mode(bus, false);
       }
 
       // Cancel rx timeout
@@ -362,11 +347,7 @@ static bool ldma_rx_handler(unsigned int chan, unsigned int iteration, void *use
       TIMER_Enable(data->rx_timer, false);
 
       // Switch back to idle/read mode
-      if (bus->mode == JOYBUS_MODE_TARGET) {
-        enter_target_read_mode(bus, true);
-      } else {
-        data->state = BUS_STATE_HOST_IDLE;
-      }
+      enter_idle_mode(bus, true);
 
       // Cancel rx timeout
       sl_sleeptimer_stop_timer(&data->rx_timeout_timer);
@@ -415,14 +396,9 @@ static bool ldma_tx_handler(unsigned int chan, unsigned int iteration, void *use
           data->done_callback(bus, 0, data->done_user_data);
       }
     } else if (data->state == BUS_STATE_TARGET_TX) {
-      // If we are handling a command response (target mode), and a target is
-      // still registered, flip back into read mode to listen for the next
-      // command. Otherwise, go idle.
-      if (bus->mode == JOYBUS_MODE_TARGET) {
-        enter_target_read_mode(bus, false);
-      } else {
-        data->state = BUS_STATE_HOST_IDLE;
-      }
+      // After sending a command response, flip back into read mode to listen
+      // for the next command.
+      enter_idle_mode(bus, false);
     }
   }
 
@@ -460,6 +436,16 @@ static void enter_target_read_mode(struct joybus *bus, bool await_idle)
 
   // Transition state
   data->state = BUS_STATE_TARGET_RX;
+}
+
+// Return to the resting state for the bus mode: target read mode, or host idle
+static void enter_idle_mode(struct joybus *bus, bool await_idle)
+{
+  if (bus->mode == JOYBUS_MODE_TARGET) {
+    enter_target_read_mode(bus, await_idle);
+  } else {
+    JOYBUS_GECKO(bus)->data.state = BUS_STATE_HOST_IDLE;
+  }
 }
 
 // Prepare an SI write operation by pre-encoding the first one or two bytes

--- a/src/backend/gecko_sdk/joybus.c
+++ b/src/backend/gecko_sdk/joybus.c
@@ -723,44 +723,10 @@ static int joybus_gecko_transfer(struct joybus *bus, const uint8_t *write_buf, u
   return 0;
 }
 
-static int joybus_gecko_target_register(struct joybus *bus, struct joybus_target *target)
-{
-  struct joybus_gecko_data *data = &JOYBUS_GECKO(bus)->data;
-
-  // Immediately start listening for commands if the bus is enabled
-  if (data->state != BUS_STATE_DISABLED) {
-    set_tx_timings(bus, BUS_MODE_TARGET);
-    enter_target_read_mode(bus, true);
-  }
-
-  return 0;
-}
-
-static int joybus_gecko_target_unregister(struct joybus *bus, struct joybus_target *target)
-{
-  struct joybus_gecko_data *data = &JOYBUS_GECKO(bus)->data;
-
-  if (data->state != BUS_STATE_DISABLED) {
-    // Cancel any ongoing RX/TX
-    TIMER_Enable(data->rx_timer, false);
-    DMADRV_StopTransfer(data->tx_dma_channel);
-
-    // Set TX timings back to host mode
-    set_tx_timings(bus, BUS_MODE_HOST);
-  }
-
-  // Set bus state to idle
-  data->state = BUS_STATE_HOST_IDLE;
-
-  return 0;
-}
-
 static const struct joybus_api gecko_api = {
-  .enable            = joybus_gecko_enable,
-  .disable           = joybus_gecko_disable,
-  .transfer          = joybus_gecko_transfer,
-  .target_register   = joybus_gecko_target_register,
-  .target_unregister = joybus_gecko_target_unregister,
+  .enable   = joybus_gecko_enable,
+  .disable  = joybus_gecko_disable,
+  .transfer = joybus_gecko_transfer,
 };
 
 int joybus_gecko_init(struct joybus_gecko *gecko_bus, GPIO_Port_TypeDef port, uint8_t pin, TIMER_TypeDef *rx_timer,

--- a/src/backend/gecko_sdk/joybus.c
+++ b/src/backend/gecko_sdk/joybus.c
@@ -242,7 +242,7 @@ void transfer_timeout(sl_sleeptimer_timer_handle_t *handle, void *user_data)
   struct joybus_gecko_data *data = &JOYBUS_GECKO(bus)->data;
 
   // Timeout occurred, switch back to idle/read mode
-  if (bus->target) {
+  if (bus->mode == JOYBUS_MODE_TARGET) {
     enter_target_read_mode(bus, true);
   } else {
     data->state = BUS_STATE_HOST_IDLE;
@@ -260,7 +260,7 @@ void target_rx_timeout(sl_sleeptimer_timer_handle_t *handle, void *user_data)
   struct joybus_gecko_data *data = &JOYBUS_GECKO(bus)->data;
 
   // Timeout occurred, switch back to idle/read mode
-  if (bus->target) {
+  if (bus->mode == JOYBUS_MODE_TARGET) {
     enter_target_read_mode(bus, true);
   } else {
     data->state = BUS_STATE_HOST_IDLE;
@@ -293,7 +293,7 @@ static bool ldma_rx_handler(unsigned int chan, unsigned int iteration, void *use
       TIMER_Enable(data->rx_timer, false);
 
       // Switch back to idle/read mode
-      if (bus->target) {
+      if (bus->mode == JOYBUS_MODE_TARGET) {
         enter_target_read_mode(bus, true);
       } else {
         data->state = BUS_STATE_HOST_IDLE;
@@ -342,7 +342,7 @@ static bool ldma_rx_handler(unsigned int chan, unsigned int iteration, void *use
         TIMER_Enable(data->rx_timer, false);
 
         // No response to send, switch back to read mode or idle
-        if (bus->target) {
+        if (bus->mode == JOYBUS_MODE_TARGET) {
           enter_target_read_mode(bus, false);
         } else {
           data->state = BUS_STATE_HOST_IDLE;
@@ -367,7 +367,7 @@ static bool ldma_rx_handler(unsigned int chan, unsigned int iteration, void *use
       TIMER_Enable(data->rx_timer, false);
 
       // Switch back to idle/read mode
-      if (bus->target) {
+      if (bus->mode == JOYBUS_MODE_TARGET) {
         enter_target_read_mode(bus, true);
       } else {
         data->state = BUS_STATE_HOST_IDLE;
@@ -423,7 +423,7 @@ static bool ldma_tx_handler(unsigned int chan, unsigned int iteration, void *use
       // If we are handling a command response (target mode), and a target is
       // still registered, flip back into read mode to listen for the next
       // command. Otherwise, go idle.
-      if (bus->target) {
+      if (bus->mode == JOYBUS_MODE_TARGET) {
         enter_target_read_mode(bus, false);
       } else {
         data->state = BUS_STATE_HOST_IDLE;
@@ -659,7 +659,7 @@ static int joybus_gecko_enable(struct joybus *bus)
   // Initialize sleeptimer for timeouts
   sl_sleeptimer_init();
 
-  if (bus->target) {
+  if (bus->mode == JOYBUS_MODE_TARGET) {
     set_tx_timings(bus, BUS_MODE_TARGET);
     enter_target_read_mode(bus, true);
   } else {
@@ -764,10 +764,11 @@ static const struct joybus_api gecko_api = {
 };
 
 int joybus_gecko_init(struct joybus_gecko *gecko_bus, GPIO_Port_TypeDef port, uint8_t pin, TIMER_TypeDef *rx_timer,
-                      USART_TypeDef *tx_usart)
+                      USART_TypeDef *tx_usart, enum joybus_mode mode)
 {
   struct joybus *bus = JOYBUS(gecko_bus);
   bus->api           = &gecko_api;
+  bus->mode          = mode;
   bus->target        = NULL;
 
   // Save the joybus configuration

--- a/src/backend/gecko_sdk/joybus.c
+++ b/src/backend/gecko_sdk/joybus.c
@@ -31,11 +31,6 @@
 #include <joybus/backend/gecko.h>
 
 enum {
-  BUS_MODE_HOST,
-  BUS_MODE_TARGET,
-};
-
-enum {
   BUS_STATE_DISABLED,
   BUS_STATE_HOST_IDLE,
   BUS_STATE_HOST_TX,
@@ -191,12 +186,12 @@ static inline void encode_byte(uint8_t *dest, uint8_t src)
   dest[3] = ((src & 0x02) ? BIT_1 : BIT_0) << 4 | ((src & 0x01) ? BIT_1 : BIT_0);
 }
 
-// Adjust TX timings for host/target mode
-static void set_tx_timings(struct joybus *bus, uint8_t mode)
+// Adjust TX timings for the bus mode
+static void set_tx_timings(struct joybus *bus)
 {
   struct joybus_gecko_data *data = &JOYBUS_GECKO(bus)->data;
 
-  if (mode == BUS_MODE_TARGET) {
+  if (bus->mode == JOYBUS_MODE_TARGET) {
     USART_BaudrateSyncSet(data->tx_usart, 0, data->target_freq * CHIPS_PER_BIT);
     data->tx_descriptors[2].xfer.srcAddr = (uint32_t)&TARGET_STOP;
   } else {
@@ -660,7 +655,7 @@ static int joybus_gecko_enable(struct joybus *bus)
   sl_sleeptimer_init();
 
   if (bus->mode == JOYBUS_MODE_TARGET) {
-    set_tx_timings(bus, BUS_MODE_TARGET);
+    set_tx_timings(bus);
     enter_target_read_mode(bus, true);
   } else {
     data->state = BUS_STATE_HOST_IDLE;
@@ -729,8 +724,8 @@ static const struct joybus_api gecko_api = {
   .transfer = joybus_gecko_transfer,
 };
 
-int joybus_gecko_init(struct joybus_gecko *gecko_bus, GPIO_Port_TypeDef port, uint8_t pin, TIMER_TypeDef *rx_timer,
-                      USART_TypeDef *tx_usart, enum joybus_mode mode)
+int joybus_gecko_init(struct joybus_gecko *gecko_bus, enum joybus_mode mode, GPIO_Port_TypeDef port, uint8_t pin,
+                      TIMER_TypeDef *rx_timer, USART_TypeDef *tx_usart)
 {
   struct joybus *bus = JOYBUS(gecko_bus);
   bus->api           = &gecko_api;

--- a/src/backend/rp2xxx/joybus.c
+++ b/src/backend/rp2xxx/joybus.c
@@ -55,7 +55,7 @@ static void configure_state_machine(struct joybus *bus)
   data->pio_configured = true;
 }
 
-// Enter either host idle mode or target read mode, depending on whether a target is registered
+// Enter either host idle mode or target read mode, depending on the bus mode
 static inline void enter_idle_mode(struct joybus *bus, bool await_idle)
 {
   struct joybus_rp2xxx_data *data = &JOYBUS_RP2XXX(bus)->data;

--- a/src/backend/rp2xxx/joybus.c
+++ b/src/backend/rp2xxx/joybus.c
@@ -22,12 +22,6 @@ enum {
   BUS_STATE_TARGET_TX,
 };
 
-enum {
-  BUS_MODE_NONE,
-  BUS_MODE_HOST,
-  BUS_MODE_TARGET,
-};
-
 // Global state to track loaded PIO programs and bus instances
 static struct {
   uint host_offset;
@@ -36,20 +30,21 @@ static struct {
   struct joybus *bus_instances[NUM_PIO_STATE_MACHINES];
 } pio_state[NUM_PIOS] = {0};
 
-// Configure the state machine for host or target mode
-static void configure_state_machine(struct joybus *bus, int mode)
+// Load the PIO program for the bus mode. The mode is fixed at init, so this
+// only needs to run once.
+static void configure_state_machine(struct joybus *bus)
 {
   struct joybus_rp2xxx_data *data = &JOYBUS_RP2XXX(bus)->data;
 
-  // Return early if already in the requested mode
-  if (data->pio_sm_mode == mode)
+  // Return early if the program is already loaded
+  if (data->pio_configured)
     return;
 
   // Disable current state machine
   pio_sm_set_enabled(data->pio, data->pio_sm, false);
 
   // Initialize the PIO program
-  if (mode == BUS_MODE_HOST) {
+  if (bus->mode == JOYBUS_MODE_HOST) {
     joybus_host_program_init(data->pio, data->pio_sm, pio_state[PIO_NUM(data->pio)].host_offset, data->gpio,
                              data->host_freq);
   } else {
@@ -57,8 +52,7 @@ static void configure_state_machine(struct joybus *bus, int mode)
                                data->target_freq);
   }
 
-  // Update the mode
-  data->pio_sm_mode = mode;
+  data->pio_configured = true;
 }
 
 // Enter either host idle mode or target read mode, depending on whether a target is registered
@@ -82,8 +76,8 @@ static inline void enter_idle_mode(struct joybus *bus, bool await_idle)
     data->read_len   = JOYBUS_BLOCK_SIZE;
     data->read_count = 0;
 
-    // Make sure the state machine is in target mode
-    configure_state_machine(bus, BUS_MODE_TARGET);
+    // Make sure the PIO program is loaded
+    configure_state_machine(bus);
 
     // Restart the state machine
     // TODO: Consider performing the state machine reset only when strictly needed
@@ -97,8 +91,8 @@ static inline void enter_idle_mode(struct joybus *bus, bool await_idle)
     // Transition state
     data->state = BUS_STATE_TARGET_RX;
   } else {
-    // Make sure the state machine is in host mode
-    configure_state_machine(bus, BUS_MODE_HOST);
+    // Make sure the PIO program is loaded
+    configure_state_machine(bus);
 
     // Enter host idle mode
     // TODO: Consider performing the state machine reset only when strictly needed
@@ -403,7 +397,7 @@ static const struct joybus_api rp2xxx_api = {
   .transfer = joybus_rp2xxx_transfer,
 };
 
-int joybus_rp2xxx_init(struct joybus_rp2xxx *rp2xxx_bus, uint8_t gpio, PIO pio, enum joybus_mode mode)
+int joybus_rp2xxx_init(struct joybus_rp2xxx *rp2xxx_bus, enum joybus_mode mode, uint8_t gpio, PIO pio)
 {
   // Save the bus API
   struct joybus *bus = JOYBUS(rp2xxx_bus);
@@ -415,7 +409,7 @@ int joybus_rp2xxx_init(struct joybus_rp2xxx *rp2xxx_bus, uint8_t gpio, PIO pio, 
   struct joybus_rp2xxx_data *data = &rp2xxx_bus->data;
   data->gpio                      = gpio;
   data->pio                       = pio;
-  data->pio_sm_mode               = BUS_MODE_NONE;
+  data->pio_configured            = false;
   data->state                     = BUS_STATE_DISABLED;
   data->host_freq                 = JOYBUS_FREQ_GCN_CONSOLE;
   data->target_freq               = JOYBUS_FREQ_GCN_CONTROLLER;

--- a/src/backend/rp2xxx/joybus.c
+++ b/src/backend/rp2xxx/joybus.c
@@ -397,12 +397,11 @@ static const struct joybus_api rp2xxx_api = {
   .transfer = joybus_rp2xxx_transfer,
 };
 
-int joybus_rp2xxx_init(struct joybus_rp2xxx *rp2xxx_bus, enum joybus_mode mode, uint8_t gpio, PIO pio)
+int joybus_rp2xxx_init(struct joybus_rp2xxx *rp2xxx_bus, uint8_t gpio, PIO pio)
 {
   // Save the bus API
   struct joybus *bus = JOYBUS(rp2xxx_bus);
   bus->api           = &rp2xxx_api;
-  bus->mode          = mode;
   bus->target        = NULL;
 
   // Save the joybus configuration

--- a/src/backend/rp2xxx/joybus.c
+++ b/src/backend/rp2xxx/joybus.c
@@ -66,7 +66,7 @@ static inline void enter_idle_mode(struct joybus *bus, bool await_idle)
 {
   struct joybus_rp2xxx_data *data = &JOYBUS_RP2XXX(bus)->data;
 
-  if (bus->target) {
+  if (bus->mode == JOYBUS_MODE_TARGET) {
     // Wait for bus idle
     if (await_idle) {
       absolute_time_t high_since = get_absolute_time();
@@ -427,11 +427,12 @@ static const struct joybus_api rp2xxx_api = {
   .target_unregister = joybus_rp2xxx_target_unregister,
 };
 
-int joybus_rp2xxx_init(struct joybus_rp2xxx *rp2xxx_bus, uint8_t gpio, PIO pio)
+int joybus_rp2xxx_init(struct joybus_rp2xxx *rp2xxx_bus, uint8_t gpio, PIO pio, enum joybus_mode mode)
 {
   // Save the bus API
   struct joybus *bus = JOYBUS(rp2xxx_bus);
   bus->api           = &rp2xxx_api;
+  bus->mode          = mode;
   bus->target        = NULL;
 
   // Save the joybus configuration

--- a/src/backend/rp2xxx/joybus.c
+++ b/src/backend/rp2xxx/joybus.c
@@ -397,34 +397,10 @@ static int joybus_rp2xxx_transfer(struct joybus *bus, const uint8_t *write_buf, 
   return 0;
 }
 
-static int joybus_rp2xxx_target_register(struct joybus *bus, struct joybus_target *target)
-{
-  struct joybus_rp2xxx_data *data = &JOYBUS_RP2XXX(bus)->data;
-
-  // Switch to target read mode if bus is enabled
-  if (data->state != BUS_STATE_DISABLED)
-    enter_idle_mode(bus, true);
-
-  return 0;
-}
-
-static int joybus_rp2xxx_target_unregister(struct joybus *bus, struct joybus_target *target)
-{
-  struct joybus_rp2xxx_data *data = &JOYBUS_RP2XXX(bus)->data;
-
-  // Switch to host idle mode if bus is enabled
-  if (data->state != BUS_STATE_DISABLED)
-    enter_idle_mode(bus, false);
-
-  return 0;
-}
-
 static const struct joybus_api rp2xxx_api = {
-  .enable            = joybus_rp2xxx_enable,
-  .disable           = joybus_rp2xxx_disable,
-  .transfer          = joybus_rp2xxx_transfer,
-  .target_register   = joybus_rp2xxx_target_register,
-  .target_unregister = joybus_rp2xxx_target_unregister,
+  .enable   = joybus_rp2xxx_enable,
+  .disable  = joybus_rp2xxx_disable,
+  .transfer = joybus_rp2xxx_transfer,
 };
 
 int joybus_rp2xxx_init(struct joybus_rp2xxx *rp2xxx_bus, uint8_t gpio, PIO pio, enum joybus_mode mode)

--- a/src/target/n64_controller.c
+++ b/src/target/n64_controller.c
@@ -273,7 +273,7 @@ void joybus_target_n64_controller_attach_pak(struct joybus_target_n64_controller
   controller->pak = pak;
 
   joybus_id_clear_status_flags(&controller->id, JOYBUS_STATUS_N64_PAK_PRESENT | JOYBUS_STATUS_N64_PAK_PULLED);
-  if (joybus_target_is_registered(JOYBUS_TARGET(controller))) {
+  if (joybus_target_is_attached(JOYBUS_TARGET(controller))) {
     joybus_id_set_status_flags(&controller->id, JOYBUS_STATUS_N64_PAK_PRESENT | JOYBUS_STATUS_N64_PAK_PULLED);
   } else {
     joybus_id_set_status_flags(&controller->id, JOYBUS_STATUS_N64_PAK_PRESENT);

--- a/test/target/test_n64_controller.c
+++ b/test/target/test_n64_controller.c
@@ -84,7 +84,7 @@ static void fill_payload(uint8_t payload[JOYBUS_PAK_BLOCK_SIZE])
 
 void setUp(void)
 {
-  // init zeroes the whole struct itself, including the registered flag
+  // init zeroes the whole struct itself, including the attached flag
   joybus_target_n64_controller_init(&controller);
 
   // Set up the fake pak, detached until a test attaches it
@@ -131,11 +131,11 @@ static void test_attach_pak_before_registration(void)
   TEST_ASSERT_EQUAL_HEX8(JOYBUS_STATUS_N64_PAK_PRESENT, controller.id.status);
 }
 
-// Test that attaching a pak while registered reports it as changed (present and pulled together)
-static void test_attach_pak_while_registered(void)
+// Test that attaching a pak while attached reports it as changed (present and pulled together)
+static void test_attach_pak_while_attached(void)
 {
   // Simulate "powered on" without involving a bus
-  controller.base.registered = true;
+  controller.base.attached = true;
 
   joybus_target_n64_controller_attach_pak(&controller, &pak);
 
@@ -174,7 +174,7 @@ static void test_identify(void)
 // Test that identify reports "pak changed" exactly once, then "pak present"
 static void test_identify_acks_pak_changed(void)
 {
-  controller.base.registered = true;
+  controller.base.attached = true;
   joybus_target_n64_controller_attach_pak(&controller, &pak);
 
   uint8_t command[] = {JOYBUS_CMD_IDENTIFY};
@@ -399,7 +399,7 @@ static void test_pak_read_no_pak(void)
 // Test that a pak read is refused while the pak change has not been acknowledged by an identify
 static void test_pak_read_refused_while_pak_changed(void)
 {
-  controller.base.registered = true;
+  controller.base.attached = true;
   joybus_target_n64_controller_attach_pak(&controller, &pak);
 
   uint16_t addr     = valid_pak_addr(0x8000);
@@ -492,7 +492,7 @@ static void test_pak_write_no_pak(void)
 // Test that a pak write is refused while the pak change has not been acknowledged by an identify
 static void test_pak_write_refused_while_pak_changed(void)
 {
-  controller.base.registered = true;
+  controller.base.attached = true;
   joybus_target_n64_controller_attach_pak(&controller, &pak);
 
   uint8_t payload[JOYBUS_PAK_BLOCK_SIZE];
@@ -545,7 +545,7 @@ static void test_unknown_command_not_supported(void)
 // Test the full pak lifecycle as the host sees it (absent -> changed -> present -> pulled)
 static void test_pak_lifecycle(void)
 {
-  controller.base.registered = true;
+  controller.base.attached = true;
   uint8_t identify[]         = {JOYBUS_CMD_IDENTIFY};
 
   // No pak after power-on
@@ -570,7 +570,7 @@ static void test_pak_lifecycle(void)
 // Test that pak reads start working after an identify acknowledges the hotplugged pak
 static void test_pak_read_works_after_changed_acked(void)
 {
-  controller.base.registered = true;
+  controller.base.attached = true;
   joybus_target_n64_controller_attach_pak(&controller, &pak);
 
   uint16_t addr      = valid_pak_addr(0x8000);
@@ -595,7 +595,7 @@ int main(void)
   // State API
   RUN_TEST(test_init_defaults);
   RUN_TEST(test_attach_pak_before_registration);
-  RUN_TEST(test_attach_pak_while_registered);
+  RUN_TEST(test_attach_pak_while_attached);
   RUN_TEST(test_detach_pak);
 
   // Identify


### PR DESCRIPTION
- No more magic switching from host to target mode, call `joybus_enable(bus, mode)` instead
- Rename `joybus_target_register` -> `joybus_attach_target`