### PR TITLE
Backend init functions take config structs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@
 
 New backends should follow the structure of existing backends in `src/backend/`.
 
-Each backend is expected to implement a `joybus_backend_init(...)` function, and provide implementations for each of the functions in the `joybus_api` struct:
+Each backend defines a `joybus_<backend>_config` struct holding the constant configuration for a bus (peripherals, transmit frequency), a `joybus_<backend>_config_default(...)` helper that fills it with sensible defaults, and a `joybus_<backend>_init(bus, config)` function. It also provides implementations for each of the functions in the `joybus_api` struct:
 
 ```c
 static const struct joybus_api mybackend_api = {
@@ -13,9 +13,10 @@ static const struct joybus_api mybackend_api = {
   .transfer = joybus_mybackend_transfer,
 };
 
-int joybus_mybackend_init(struct joybus *bus, ...)
+int joybus_mybackend_init(struct joybus *bus, struct joybus_mybackend_config config)
 {
-  bus->api = &mybackend_api;
+  bus->api  = &mybackend_api;
+  bus->freq = config.freq;
 
   // Rest of initialization code...
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ struct joybus *bus = JOYBUS(&rp2xxx_bus);
 
 int main() {
   // Initialize the Joybus on a specific GPIO pin and PIO instance
-  joybus_rp2xxx_init(&rp2xxx_bus, JOYBUS_GPIO, pio0);
+  joybus_rp2xxx_init(&rp2xxx_bus, joybus_rp2xxx_config_default(JOYBUS_GPIO));
 
   // ...your code here
 
@@ -82,7 +82,7 @@ void read_controller() {
 
 void main() {
   // Initialize the Joybus and enable it in host mode
-  joybus_rp2xxx_init(&rp2xxx_bus, MY_GPIO, pio0);
+  joybus_rp2xxx_init(&rp2xxx_bus, joybus_rp2xxx_config_default(MY_GPIO));
   joybus_enable(bus, JOYBUS_MODE_HOST);
 
   // Read the controller state in a loop
@@ -110,7 +110,7 @@ struct joybus_target_gcn_controller controller;
 
 void main() {
   // Initialize the Joybus
-  joybus_rp2xxx_init(&rp2xxx_bus, MY_GPIO, pio0);
+  joybus_rp2xxx_init(&rp2xxx_bus, joybus_rp2xxx_config_default(MY_GPIO));
 
   // Initialize a GameCube controller target and attach it to the bus
   joybus_target_gcn_controller_init(&controller);

--- a/examples/gecko/gcn-host/app.c
+++ b/examples/gecko/gcn-host/app.c
@@ -9,8 +9,6 @@
 // Change these defines to match your hardware setup
 #define JOYBUS_PORT             gpioPortD
 #define JOYBUS_PIN              3
-#define JOYBUS_TIMER            TIMER0
-#define JOYBUS_USART            USART0
 #define LED_PORT                gpioPortA
 #define LED_PIN                 4
 
@@ -91,7 +89,7 @@ void app_init(void)
   GPIO_PinModeSet(LED_PORT, LED_PIN, gpioModePushPull, 0);
 
   // Initialize Joybus
-  joybus_gecko_init(&gecko_bus, JOYBUS_PORT, JOYBUS_PIN, JOYBUS_TIMER, JOYBUS_USART);
+  joybus_gecko_init(&gecko_bus, joybus_gecko_config_default(JOYBUS_PORT, JOYBUS_PIN));
   joybus_enable(bus, JOYBUS_MODE_HOST);
 
   // Poll for Joybus data at regular intervals

--- a/examples/gecko/gcn-target/app.c
+++ b/examples/gecko/gcn-target/app.c
@@ -9,8 +9,6 @@
 // Change these defines to match your hardware setup
 #define JOYBUS_DATA_PORT  gpioPortD
 #define JOYBUS_DATA_PIN   3
-#define JOYBUS_TIMER      TIMER0
-#define JOYBUS_USART      USART0
 #define BTN_PORT          gpioPortC
 #define BTN_PIN           7
 
@@ -28,7 +26,7 @@ void app_init(void)
   GPIO_PinModeSet(BTN_PORT, BTN_PIN, gpioModeInput, 1);
 
   // Initialize the Joybus
-  joybus_gecko_init(&gecko_bus, JOYBUS_DATA_PORT, JOYBUS_DATA_PIN, JOYBUS_TIMER, JOYBUS_USART);
+  joybus_gecko_init(&gecko_bus, joybus_gecko_config_default(JOYBUS_DATA_PORT, JOYBUS_DATA_PIN));
 
   // Initialize a GameCube controller target as a standard controller
   joybus_target_gcn_controller_init(&gcn_controller);

--- a/examples/pico-sdk/gcn-adapter-nintendo/main.c
+++ b/examples/pico-sdk/gcn-adapter-nintendo/main.c
@@ -310,7 +310,7 @@ int main(void)
 
   // Initialize Joybus channels
   for (int i = 0; i < GCCA_JOYBUS_CHANNELS; i++) {
-    joybus_rp2xxx_init(&rp2xxx_bus[i], JOYBUS_GPIOS[i], pio0);
+    joybus_rp2xxx_init(&rp2xxx_bus[i], joybus_rp2xxx_config_default(JOYBUS_GPIOS[i]));
     joybus_enable(JOYBUS(&rp2xxx_bus[i]), JOYBUS_MODE_HOST);
 
     reset_bus_state(i);

--- a/examples/pico-sdk/gcn-adapter-usb-hid/main.c
+++ b/examples/pico-sdk/gcn-adapter-usb-hid/main.c
@@ -193,7 +193,7 @@ int main(void)
   tusb_init();
 
   // Initialize Joybus
-  joybus_rp2xxx_init(&rp2xxx_bus, JOYBUS_GPIO, pio0);
+  joybus_rp2xxx_init(&rp2xxx_bus, joybus_rp2xxx_config_default(JOYBUS_GPIO));
   joybus_enable(bus, JOYBUS_MODE_HOST);
 
   // Poll for Joybus data and send HID reports at regular intervals

--- a/examples/pico-sdk/gcn-host/main.c
+++ b/examples/pico-sdk/gcn-host/main.c
@@ -88,7 +88,7 @@ int main()
   gpio_put(LED_GPIO, 0);
 
   // Initialize Joybus
-  joybus_rp2xxx_init(&rp2xxx_bus, JOYBUS_GPIO, pio0);
+  joybus_rp2xxx_init(&rp2xxx_bus, joybus_rp2xxx_config_default(JOYBUS_GPIO));
   joybus_enable(bus, JOYBUS_MODE_HOST);
 
   // Poll for Joybus data at regular intervals

--- a/examples/pico-sdk/gcn-target/main.c
+++ b/examples/pico-sdk/gcn-target/main.c
@@ -20,7 +20,7 @@ int main()
   gpio_pull_up(BUTTON_A_GPIO);
 
   // Initialize the Joybus
-  joybus_rp2xxx_init(&rp2xxx_bus, JOYBUS_GPIO, pio0);
+  joybus_rp2xxx_init(&rp2xxx_bus, joybus_rp2xxx_config_default(JOYBUS_GPIO));
 
   // Initialize a GameCube controller target as a standard controller
   joybus_target_gcn_controller_init(&gcn_controller);

--- a/examples/pico-sdk/n64-adapter-usb-hid/main.c
+++ b/examples/pico-sdk/n64-adapter-usb-hid/main.c
@@ -145,7 +145,7 @@ int main(void)
   tusb_init();
 
   // Initialize Joybus
-  joybus_rp2xxx_init(&rp2xxx_bus, JOYBUS_GPIO, pio0);
+  joybus_rp2xxx_init(&rp2xxx_bus, joybus_rp2xxx_config_default(JOYBUS_GPIO));
   joybus_enable(bus, JOYBUS_MODE_HOST);
 
   // Poll for Joybus data and send HID reports at regular intervals

--- a/examples/pico-sdk/n64-host/main.c
+++ b/examples/pico-sdk/n64-host/main.c
@@ -80,7 +80,7 @@ int main()
   gpio_put(LED_GPIO, 0);
 
   // Initialize Joybus
-  joybus_rp2xxx_init(&rp2xxx_bus, JOYBUS_GPIO, pio0);
+  joybus_rp2xxx_init(&rp2xxx_bus, joybus_rp2xxx_config_default(JOYBUS_GPIO));
   joybus_enable(bus, JOYBUS_MODE_HOST);
 
   // Poll the controller once per "frame"

--- a/examples/pico-sdk/n64-target/main.c
+++ b/examples/pico-sdk/n64-target/main.c
@@ -54,7 +54,7 @@ static int8_t read_stick_axis(uint gpio, int origin, bool inverted)
 int main()
 {
   // Initialize the Joybus
-  joybus_rp2xxx_init(&rp2xxx_bus, JOYBUS_GPIO, pio0);
+  joybus_rp2xxx_init(&rp2xxx_bus, joybus_rp2xxx_config_default(JOYBUS_GPIO));
 
   // Initialize a N64 controller target as a standard controller
   joybus_target_n64_controller_init(&n64_controller);

--- a/include/joybus/backend/gecko.h
+++ b/include/joybus/backend/gecko.h
@@ -85,19 +85,53 @@ struct joybus_gecko {
 };
 
 /**
- * Initialize a Gecko Joybus instance.
+ * Configuration for a Gecko Joybus instance.
  *
  * Note: Some peripherals cannot be used on certain ports, check the DBUS
  * Routing Table in the reference manual for your MCU.
+ */
+struct joybus_gecko_config {
+  /// GPIO port to use for the Joybus data line
+  GPIO_Port_TypeDef gpio_port;
+
+  /// GPIO pin to use for the Joybus data line
+  uint8_t gpio_pin;
+
+  /// TIMER peripheral to use for receiving data
+  TIMER_TypeDef *rx_timer;
+
+  /// USART peripheral to use for transmitting data
+  USART_TypeDef *tx_usart;
+
+  /// Transmit frequency, in Hz
+  uint32_t freq;
+};
+
+/**
+ * Build a Gecko config with default values.
  *
- * @param gecko_bus the Gecko Joybus instance to initialize
  * @param port the GPIO port to use for the Joybus data line
  * @param pin the GPIO pin to use for the Joybus data line
- * @param rx_timer the TIMER peripheral to use for receiving data
- * @param tx_usart the USART peripheral to use for transmitting data
+ * @return a config with the given GPIO, the TIMER0/USART0 peripherals, and a nominal frequency
+ */
+static inline struct joybus_gecko_config joybus_gecko_config_default(GPIO_Port_TypeDef port, uint8_t pin)
+{
+  return (struct joybus_gecko_config){
+    .gpio_port = port,
+    .gpio_pin  = pin,
+    .rx_timer  = TIMER0,
+    .tx_usart  = USART0,
+    .freq      = JOYBUS_FREQ_NOMINAL,
+  };
+}
+
+/**
+ * Initialize a Gecko Joybus instance.
+ *
+ * @param gecko_bus the Gecko Joybus instance to initialize
+ * @param config the configuration to use, eg. from joybus_gecko_config_default()
  * @return 0 on success, a negative joybus_error on failure
  */
-int joybus_gecko_init(struct joybus_gecko *gecko_bus, GPIO_Port_TypeDef port, uint8_t pin, TIMER_TypeDef *rx_timer,
-                      USART_TypeDef *tx_usart);
+int joybus_gecko_init(struct joybus_gecko *gecko_bus, struct joybus_gecko_config config);
 
 /** @} */

--- a/include/joybus/backend/gecko.h
+++ b/include/joybus/backend/gecko.h
@@ -34,10 +34,6 @@ struct joybus_gecko_data {
   // Bus state
   uint8_t state;
 
-  // Bus frequencies
-  uint32_t host_freq;
-  uint32_t target_freq;
-
   // GPIO configuration
   GPIO_Port_TypeDef gpio_port;
   uint8_t gpio_pin;
@@ -60,8 +56,7 @@ struct joybus_gecko_data {
   void *done_user_data;
 
   // RX timings
-  uint16_t host_pulse_period_half;
-  uint16_t target_pulse_period_half;
+  uint16_t pulse_period_half;
   uint16_t bus_idle_period;
 
   // RX ping-pong LDMA configuration

--- a/include/joybus/backend/rp2xxx.h
+++ b/include/joybus/backend/rp2xxx.h
@@ -60,13 +60,41 @@ struct joybus_rp2xxx {
 };
 
 /**
+ * Configuration for a RP2xxx Joybus instance.
+ */
+struct joybus_rp2xxx_config {
+  /// GPIO pin to use for the Joybus data line
+  uint8_t gpio;
+
+  /// PIO instance to use (eg. pio0 or pio1)
+  PIO pio;
+
+  /// Transmit frequency, in Hz
+  uint32_t freq;
+};
+
+/**
+ * Build a RP2xxx config with default values.
+ *
+ * @param gpio the GPIO pin to use for the Joybus data line
+ * @return a config with the given GPIO, the pio0 instance, and a nominal frequency
+ */
+static inline struct joybus_rp2xxx_config joybus_rp2xxx_config_default(uint8_t gpio)
+{
+  return (struct joybus_rp2xxx_config){
+    .gpio = gpio,
+    .pio  = pio0,
+    .freq = JOYBUS_FREQ_NOMINAL,
+  };
+}
+
+/**
  * Initialize a RP2xxx Joybus instance.
  *
  * @param rp2xxx_bus the RP2xxx Joybus instance to initialize
- * @param gpio the GPIO pin to use for the Joybus data line
- * @param pio the PIO instance to use (eg. pio0 or pio1)
+ * @param config the configuration to use, eg. from joybus_rp2xxx_config_default()
  * @return 0 on success, a negative joybus_error on failure
  */
-int joybus_rp2xxx_init(struct joybus_rp2xxx *rp2xxx_bus, uint8_t gpio, PIO pio);
+int joybus_rp2xxx_init(struct joybus_rp2xxx *rp2xxx_bus, struct joybus_rp2xxx_config config);
 
 /** @} */

--- a/include/joybus/backend/rp2xxx.h
+++ b/include/joybus/backend/rp2xxx.h
@@ -24,10 +24,6 @@ struct joybus_rp2xxx_data {
   // Bus state
   uint8_t state;
 
-  // Bus frequencies
-  uint32_t target_freq;
-  uint32_t host_freq;
-
   // GPIO configuration
   uint gpio;
 

--- a/include/joybus/bus.h
+++ b/include/joybus/bus.h
@@ -13,6 +13,9 @@
 
 struct joybus;
 
+/// Nominal Joybus frequency, matching an OEM N64/GameCube controller.
+#define JOYBUS_FREQ_NOMINAL             250000
+
 /// Joybus frequency of an N64 console (NUS-001).
 #define JOYBUS_FREQ_N64_CONSOLE         244141 // PIF-NUS @ 15.625MHz / 64
 
@@ -64,7 +67,10 @@ struct joybus;
  * The role a Joybus instance plays on the bus.
  */
 enum joybus_mode {
+  /** Host mode, sends commands and reads responses from a target device. */
   JOYBUS_MODE_HOST,
+
+  /** Target mode, listens for commands from a host device and responds accordingly. */
   JOYBUS_MODE_TARGET,
 };
 
@@ -100,10 +106,18 @@ struct joybus_host_op {
  * A Joybus instance.
  */
 struct joybus {
+  /** The backend API implementation for this Joybus instance. */
   const struct joybus_api *api;
 
+  /** The operating mode of this Joybus instance (host or target). */
   enum joybus_mode mode;
+
+  /** The frequency of the bus, in Hz. */
+  uint32_t freq;
+
+  /** The target device attached to this Joybus instance, if any. */
   struct joybus_target *target;
+
   uint8_t command_buffer[JOYBUS_BLOCK_SIZE];
   uint8_t response_buffer[JOYBUS_BLOCK_SIZE];
   struct joybus_host_op host_op;

--- a/src/backend/gecko_sdk/joybus.c
+++ b/src/backend/gecko_sdk/joybus.c
@@ -147,10 +147,10 @@ static inline unsigned long get_usart_ldma_signal(USART_TypeDef *usart)
 }
 
 // Process received SI edge timings into a byte
-static inline void decode_pulses(struct joybus *bus, uint8_t *dest, const uint16_t *src, uint16_t threshold,
-                                 uint8_t byte_index)
+static inline void decode_pulses(struct joybus *bus, uint8_t *dest, const uint16_t *src, uint8_t byte_index)
 {
   struct joybus_gecko_data *data = &JOYBUS_GECKO(bus)->data;
+  uint16_t threshold             = data->pulse_period_half;
 
   uint8_t result = 0;
   if (byte_index == 0) {
@@ -185,20 +185,6 @@ static inline void encode_byte(uint8_t *dest, uint8_t src)
   dest[1] = ((src & 0x20) ? BIT_1 : BIT_0) << 4 | ((src & 0x10) ? BIT_1 : BIT_0);
   dest[2] = ((src & 0x08) ? BIT_1 : BIT_0) << 4 | ((src & 0x04) ? BIT_1 : BIT_0);
   dest[3] = ((src & 0x02) ? BIT_1 : BIT_0) << 4 | ((src & 0x01) ? BIT_1 : BIT_0);
-}
-
-// Adjust TX timings for the bus mode
-static void set_tx_timings(struct joybus *bus)
-{
-  struct joybus_gecko_data *data = &JOYBUS_GECKO(bus)->data;
-
-  USART_BaudrateSyncSet(data->tx_usart, 0, bus->freq * CHIPS_PER_BIT);
-
-  if (bus->mode == JOYBUS_MODE_TARGET) {
-    data->tx_descriptors[2].xfer.srcAddr = (uint32_t)&TARGET_STOP;
-  } else {
-    data->tx_descriptors[2].xfer.srcAddr = (uint32_t)&HOST_STOP;
-  }
 }
 
 // Wait for the Joybus to be idle
@@ -271,8 +257,7 @@ static bool ldma_rx_handler(unsigned int chan, unsigned int iteration, void *use
 
   if (data->state == BUS_STATE_HOST_RX) {
     // Process the received pulses into the byte buffer
-    decode_pulses(bus, &data->read_buf[iteration - 1], data->rx_edge_timings[data->rx_current_buffer],
-                  data->pulse_period_half, iteration - 1);
+    decode_pulses(bus, &data->read_buf[iteration - 1], data->rx_edge_timings[data->rx_current_buffer], iteration - 1);
     data->rx_current_buffer ^= 1;
 
     if (iteration == data->read_len) {
@@ -305,8 +290,7 @@ static bool ldma_rx_handler(unsigned int chan, unsigned int iteration, void *use
     }
   } else if (data->state == BUS_STATE_TARGET_RX) {
     // Process the received pulses into the byte buffer
-    decode_pulses(bus, &data->read_buf[iteration - 1], data->rx_edge_timings[data->rx_current_buffer],
-                  data->pulse_period_half, iteration - 1);
+    decode_pulses(bus, &data->read_buf[iteration - 1], data->rx_edge_timings[data->rx_current_buffer], iteration - 1);
     data->rx_current_buffer ^= 1;
 
     // Handle the received byte
@@ -590,9 +574,9 @@ static int enable_tx(struct joybus *bus)
     LDMA_DESCRIPTOR_LINKREL_M2P_BYTE(data->tx_encoded_bytes[1], &(data->tx_usart->TXDATA), CHIPS_PER_BIT, -1);
   data->tx_descriptors[1].xfer.decLoopCnt = 1;
 
-  // LDMA stop bit descriptor
-  data->tx_descriptors[2] = (LDMA_Descriptor_t)
-    LDMA_DESCRIPTOR_SINGLE_M2P_BYTE(&HOST_STOP, &(data->tx_usart->TXDATA), 1);
+  // LDMA stop bit descriptor (the stop symbol differs between host and target)
+  data->tx_descriptors[2] = (LDMA_Descriptor_t)LDMA_DESCRIPTOR_SINGLE_M2P_BYTE(
+    bus->mode == JOYBUS_MODE_TARGET ? &TARGET_STOP : &HOST_STOP, &(data->tx_usart->TXDATA), 1);
   // clang-format on
 
   return 0;
@@ -640,7 +624,6 @@ static int joybus_gecko_enable(struct joybus *bus)
   sl_sleeptimer_init();
 
   if (bus->mode == JOYBUS_MODE_TARGET) {
-    set_tx_timings(bus);
     enter_target_read_mode(bus, true);
   } else {
     data->state = BUS_STATE_HOST_IDLE;
@@ -709,20 +692,19 @@ static const struct joybus_api gecko_api = {
   .transfer = joybus_gecko_transfer,
 };
 
-int joybus_gecko_init(struct joybus_gecko *gecko_bus, GPIO_Port_TypeDef port, uint8_t pin, TIMER_TypeDef *rx_timer,
-                      USART_TypeDef *tx_usart)
+int joybus_gecko_init(struct joybus_gecko *gecko_bus, struct joybus_gecko_config config)
 {
   struct joybus *bus = JOYBUS(gecko_bus);
   bus->api           = &gecko_api;
-  bus->freq          = JOYBUS_FREQ_NOMINAL;
+  bus->freq          = config.freq;
   bus->target        = NULL;
 
   // Save the joybus configuration
   struct joybus_gecko_data *data = &gecko_bus->data;
-  data->gpio_port                = port;
-  data->gpio_pin                 = pin;
-  data->rx_timer                 = rx_timer;
-  data->tx_usart                 = tx_usart;
+  data->gpio_port                = config.gpio_port;
+  data->gpio_pin                 = config.gpio_pin;
+  data->rx_timer                 = config.rx_timer;
+  data->tx_usart                 = config.tx_usart;
   data->state                    = BUS_STATE_DISABLED;
 
   return 0;

--- a/src/backend/gecko_sdk/joybus.c
+++ b/src/backend/gecko_sdk/joybus.c
@@ -192,11 +192,11 @@ static void set_tx_timings(struct joybus *bus)
 {
   struct joybus_gecko_data *data = &JOYBUS_GECKO(bus)->data;
 
+  USART_BaudrateSyncSet(data->tx_usart, 0, bus->freq * CHIPS_PER_BIT);
+
   if (bus->mode == JOYBUS_MODE_TARGET) {
-    USART_BaudrateSyncSet(data->tx_usart, 0, data->target_freq * CHIPS_PER_BIT);
     data->tx_descriptors[2].xfer.srcAddr = (uint32_t)&TARGET_STOP;
   } else {
-    USART_BaudrateSyncSet(data->tx_usart, 0, data->host_freq * CHIPS_PER_BIT);
     data->tx_descriptors[2].xfer.srcAddr = (uint32_t)&HOST_STOP;
   }
 }
@@ -272,7 +272,7 @@ static bool ldma_rx_handler(unsigned int chan, unsigned int iteration, void *use
   if (data->state == BUS_STATE_HOST_RX) {
     // Process the received pulses into the byte buffer
     decode_pulses(bus, &data->read_buf[iteration - 1], data->rx_edge_timings[data->rx_current_buffer],
-                  data->target_pulse_period_half, iteration - 1);
+                  data->pulse_period_half, iteration - 1);
     data->rx_current_buffer ^= 1;
 
     if (iteration == data->read_len) {
@@ -306,7 +306,7 @@ static bool ldma_rx_handler(unsigned int chan, unsigned int iteration, void *use
   } else if (data->state == BUS_STATE_TARGET_RX) {
     // Process the received pulses into the byte buffer
     decode_pulses(bus, &data->read_buf[iteration - 1], data->rx_edge_timings[data->rx_current_buffer],
-                  data->host_pulse_period_half, iteration - 1);
+                  data->pulse_period_half, iteration - 1);
     data->rx_current_buffer ^= 1;
 
     // Handle the received byte
@@ -516,10 +516,9 @@ static int enable_rx(struct joybus *bus)
     (data->gpio_port << _GPIO_TIMER_CC0ROUTE_PORT_SHIFT) | (data->gpio_pin << _GPIO_TIMER_CC0ROUTE_PIN_SHIFT);
 
   // Set up the timings for rx pulses
-  uint32_t rx_timer_freq         = CMU_ClockFreqGet(get_timer_clock(data->rx_timer));
-  data->host_pulse_period_half   = (rx_timer_freq / data->host_freq) / 2;
-  data->target_pulse_period_half = (rx_timer_freq / data->target_freq) / 2;
-  data->bus_idle_period          = rx_timer_freq / 1000000UL * JOYBUS_BUS_IDLE_US;
+  uint32_t rx_timer_freq  = CMU_ClockFreqGet(get_timer_clock(data->rx_timer));
+  data->pulse_period_half = (rx_timer_freq / bus->freq) / 2;
+  data->bus_idle_period   = rx_timer_freq / 1000000UL * JOYBUS_BUS_IDLE_US;
 
   // LDMA RX configuration
   data->rx_config = (LDMA_TransferCfg_t)LDMA_TRANSFER_CFG_PERIPHERAL(get_timer_ldma_signal(data->rx_timer));
@@ -567,7 +566,7 @@ static int enable_tx(struct joybus *bus)
 
   // Initialize USART
   USART_InitSync_TypeDef usartConfig = USART_INITSYNC_DEFAULT;
-  usartConfig.baudrate               = data->host_freq * CHIPS_PER_BIT;
+  usartConfig.baudrate               = bus->freq * CHIPS_PER_BIT;
   usartConfig.msbf                   = true;
   USART_InitSync(data->tx_usart, &usartConfig);
 
@@ -715,6 +714,7 @@ int joybus_gecko_init(struct joybus_gecko *gecko_bus, GPIO_Port_TypeDef port, ui
 {
   struct joybus *bus = JOYBUS(gecko_bus);
   bus->api           = &gecko_api;
+  bus->freq          = JOYBUS_FREQ_NOMINAL;
   bus->target        = NULL;
 
   // Save the joybus configuration
@@ -724,8 +724,6 @@ int joybus_gecko_init(struct joybus_gecko *gecko_bus, GPIO_Port_TypeDef port, ui
   data->rx_timer                 = rx_timer;
   data->tx_usart                 = tx_usart;
   data->state                    = BUS_STATE_DISABLED;
-  data->host_freq                = JOYBUS_FREQ_GCN_CONSOLE;
-  data->target_freq              = JOYBUS_FREQ_GCN_CONTROLLER;
 
   return 0;
 }

--- a/src/backend/rp2xxx/joybus.c
+++ b/src/backend/rp2xxx/joybus.c
@@ -396,18 +396,18 @@ static const struct joybus_api rp2xxx_api = {
   .transfer = joybus_rp2xxx_transfer,
 };
 
-int joybus_rp2xxx_init(struct joybus_rp2xxx *rp2xxx_bus, uint8_t gpio, PIO pio)
+int joybus_rp2xxx_init(struct joybus_rp2xxx *rp2xxx_bus, struct joybus_rp2xxx_config config)
 {
   // Save the bus API
   struct joybus *bus = JOYBUS(rp2xxx_bus);
   bus->api           = &rp2xxx_api;
-  bus->freq          = JOYBUS_FREQ_NOMINAL;
+  bus->freq          = config.freq;
   bus->target        = NULL;
 
   // Save the joybus configuration
   struct joybus_rp2xxx_data *data = &rp2xxx_bus->data;
-  data->gpio                      = gpio;
-  data->pio                       = pio;
+  data->gpio                      = config.gpio;
+  data->pio                       = config.pio;
   data->pio_configured            = false;
   data->state                     = BUS_STATE_DISABLED;
   data->last_transfer_time        = nil_time;

--- a/src/backend/rp2xxx/joybus.c
+++ b/src/backend/rp2xxx/joybus.c
@@ -45,11 +45,10 @@ static void configure_state_machine(struct joybus *bus)
 
   // Initialize the PIO program
   if (bus->mode == JOYBUS_MODE_HOST) {
-    joybus_host_program_init(data->pio, data->pio_sm, pio_state[PIO_NUM(data->pio)].host_offset, data->gpio,
-                             data->host_freq);
+    joybus_host_program_init(data->pio, data->pio_sm, pio_state[PIO_NUM(data->pio)].host_offset, data->gpio, bus->freq);
   } else {
     joybus_target_program_init(data->pio, data->pio_sm, pio_state[PIO_NUM(data->pio)].target_offset, data->gpio,
-                               data->target_freq);
+                               bus->freq);
   }
 
   data->pio_configured = true;
@@ -402,6 +401,7 @@ int joybus_rp2xxx_init(struct joybus_rp2xxx *rp2xxx_bus, uint8_t gpio, PIO pio)
   // Save the bus API
   struct joybus *bus = JOYBUS(rp2xxx_bus);
   bus->api           = &rp2xxx_api;
+  bus->freq          = JOYBUS_FREQ_NOMINAL;
   bus->target        = NULL;
 
   // Save the joybus configuration
@@ -410,8 +410,6 @@ int joybus_rp2xxx_init(struct joybus_rp2xxx *rp2xxx_bus, uint8_t gpio, PIO pio)
   data->pio                       = pio;
   data->pio_configured            = false;
   data->state                     = BUS_STATE_DISABLED;
-  data->host_freq                 = JOYBUS_FREQ_GCN_CONSOLE;
-  data->target_freq               = JOYBUS_FREQ_GCN_CONTROLLER;
   data->last_transfer_time        = nil_time;
 
   return 0;


### PR DESCRIPTION
- **Don't have a seperate host/target bus frequency**
- **Provide a struct to backend _init functions, provide some sensible defaults**
