### PR TITLE
Add GameCube-to-DS4 USB adapter example

### DIFF
--- a/.github/workflows/pico_examples.yml
+++ b/.github/workflows/pico_examples.yml
@@ -38,6 +38,7 @@ jobs:
     strategy:
       matrix:
         example:
+          - gcn-adapter-ds4
           - gcn-adapter-nintendo
           - gcn-adapter-usb-hid
           - gcn-host

--- a/examples/pico-sdk/gcn-adapter-ds4/CMakeLists.txt
+++ b/examples/pico-sdk/gcn-adapter-ds4/CMakeLists.txt
@@ -1,0 +1,33 @@
+# Set the minimum CMake version
+cmake_minimum_required(VERSION 3.20)
+
+# Include the Pico SDK
+include($ENV{PICO_SDK_PATH}/external/pico_sdk_import.cmake)
+
+# Configure project
+project(gcn-adapter-ds4 C CXX ASM)
+
+# CMake target
+set(TARGET gcn-adapter-ds4)
+
+# Initialize the Pico SDK
+pico_sdk_init()
+
+# Define platform for libjoybus
+set(JOYBUS_BACKEND rp2xxx)
+
+# Make libjoybus available
+set(LIBJOYBUS_ROOT ${CMAKE_CURRENT_LIST_DIR}/../../..)
+add_subdirectory(${LIBJOYBUS_ROOT} ${CMAKE_BINARY_DIR}/_deps/libjoybus-build)
+
+# Create the executable
+add_executable(${TARGET} main.c usb_descriptors.c)
+
+# Specify the include paths
+target_include_directories(${TARGET} PUBLIC .)
+
+# Depend on Pico SDK, TinyUSB, and libjoybus
+target_link_libraries(${TARGET} pico_stdlib tinyusb_device tinyusb_board joybus)
+
+# Generate UF2 file
+pico_add_extra_outputs(${TARGET})

--- a/examples/pico-sdk/gcn-adapter-ds4/README.md
+++ b/examples/pico-sdk/gcn-adapter-ds4/README.md
@@ -1,0 +1,61 @@
+# Simple GameCube USB Adapter Example
+
+Implements a single port GameCube controller to USB adapter that presents itself
+as a Sony DualShock 4 (DS4) controller.
+
+
+## Rumble (OS-native on macOS)
+
+The adapter emulates a DualShock 4 (`054C:05C4`), a controller macOS recognizes
+natively through its GameController framework. Because of this, rumble works with
+no extra software: games, Steam, and the OS drive the DS4 rumble output report
+(`0x05`) directly, and the adapter forwards it to the GameCube controller's motor.
+
+macOS has no generic HID PID (force feedback) driver — unlike Windows DirectInput
+and Linux `hid-pidff`, it only drives rumble on controllers it explicitly supports
+(DualShock 4/DualSense, Xbox, MFi). Emulating a DS4 is therefore how this example
+gets OS-native rumble on macOS. The DS4 rumble motors have independent magnitudes,
+but the GameCube motor is on/off only, so any non-zero magnitude turns it on.
+
+The GameCube controls are mapped onto the DS4 layout as follows:
+
+| GameCube | DualShock 4        |
+| -------- | ------------------ |
+| A        | Cross              |
+| B        | Circle             |
+| X        | Square             |
+| Y        | Triangle           |
+| Start    | Options            |
+| Z        | R1                 |
+| L        | L2 (analog + click)|
+| R        | R2 (analog + click)|
+| D-pad    | D-pad              |
+| Stick    | Left stick         |
+| C-stick  | Right stick        |
+
+The PS4 console authentication handshake is **not** implemented, so this adapter
+works with macOS (and other PC hosts) but will not be accepted by a PS4/PS5.
+
+
+## Building
+
+```bash
+cmake -Bbuild . && cmake --build build
+```
+
+## Flashing
+
+Enter bootloader mode by holding the BOOTSEL button while plugging in the Pico. Then copy the generated `build/gcn-adapter-ds4.uf2` file to the RPI-RP2 drive that appears, or use `picotool`:
+
+```bash
+picotool load -f build/gcn-adapter-ds4.uf2
+```
+
+## Wiring
+
+- GameCube controller 5V to the VSYS pin on your Pico
+- GameCube controller 3.3V to the 3.3V pin on your Pico
+- GameCube controller GND to a GND pin on your Pico
+- Pick any GPIO for the data line, and connect it to the data line on the GameCube controller port
+
+Pull-up resistor is required for the data line, the recommended value is 750Ω.

--- a/examples/pico-sdk/gcn-adapter-ds4/main.c
+++ b/examples/pico-sdk/gcn-adapter-ds4/main.c
@@ -1,0 +1,339 @@
+#include <stdio.h>
+#include <string.h>
+
+#include "tusb.h"
+#include "pico/stdlib.h"
+
+#include <joybus/joybus.h>
+#include "joybus/host/gcn.h"
+#include <joybus/backend/rp2xxx.h>
+
+#define JOYBUS_GPIO                 12
+#define POLL_INTERVAL               1
+
+// DualShock 4 report IDs
+#define DS4_INPUT_REPORT_ID         0x01
+#define DS4_OUTPUT_REPORT_ID        0x05
+
+// DualShock 4 D-pad (hat) values
+#define DS4_HAT_UP                  0x00
+#define DS4_HAT_UP_RIGHT            0x01
+#define DS4_HAT_RIGHT               0x02
+#define DS4_HAT_DOWN_RIGHT          0x03
+#define DS4_HAT_DOWN                0x04
+#define DS4_HAT_DOWN_LEFT           0x05
+#define DS4_HAT_LEFT                0x06
+#define DS4_HAT_UP_LEFT             0x07
+#define DS4_HAT_NEUTRAL             0x08
+
+// Joybus instance
+static struct joybus_rp2xxx rp2xxx_bus;
+static struct joybus *bus = JOYBUS(&rp2xxx_bus);
+
+// Buffers for Joybus responses
+static struct joybus_id id;
+static struct joybus_gcn_controller_state input;
+static struct joybus_gcn_controller_state origin;
+
+// Buffer for building USB reports
+static uint8_t report_buf[CFG_TUD_HID_EP_BUFSIZE];
+
+// 6-bit report counter included in every DS4 input report
+static uint8_t report_counter = 0;
+
+// Polling mode
+enum { POLL_MODE_IDENTIFY, POLL_MODE_READ };
+static uint8_t poll_mode = POLL_MODE_IDENTIFY;
+
+// Rumble motor state, driven by DS4 output reports from the host
+static uint8_t motor_state = JOYBUS_GCN_MOTOR_STOP;
+
+// DualShock 4 feature reports the host GETs during init. macOS enumerates the
+// controller from the descriptors and does not require the console
+// authentication handshake, but returning valid calibration/version data avoids
+// stalled control transfers. Bytes are the canned responses used by GP2040-CE.
+static const uint8_t ds4_feature_calibration[] = { // report 0x02 (IMU calibration)
+  0xfe, 0xff, 0x0e, 0x00, 0x04, 0x00, 0xd4, 0x22,
+  0x2a, 0xdd, 0xbb, 0x22, 0x5e, 0xdd, 0x81, 0x22,
+  0x84, 0xdd, 0x1c, 0x02, 0x1c, 0x02, 0x85, 0x1f,
+  0xb0, 0xe0, 0xc6, 0x20, 0xb5, 0xe0, 0xb1, 0x20,
+  0x83, 0xdf, 0x0c, 0x00
+};
+
+static const uint8_t ds4_feature_definition[] = { // report 0x03 (controller definition)
+  0x21, 0x27, 0x04, 0xcf, 0x00, 0x2c, 0x56,
+  0x08, 0x00, 0x3d, 0x00, 0xe8, 0x03, 0x04, 0x00,
+  0xff, 0x7f, 0x0d, 0x0d, 0x00, 0x00, 0x00, 0x00,
+  0x0d, 0x84, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00,
+  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+};
+
+static const uint8_t ds4_feature_version[] = { // report 0xA3 (firmware version/date)
+  0x4a, 0x75, 0x6e, 0x20, 0x20, 0x39, 0x20, 0x32,
+  0x30, 0x31, 0x37, 0x00, 0x00, 0x00, 0x00, 0x00,
+  0x31, 0x32, 0x3a, 0x33, 0x36, 0x3a, 0x34, 0x31,
+  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+  0x00, 0x01, 0x08, 0xb4, 0x01, 0x00, 0x00, 0x00,
+  0x07, 0xa0, 0x10, 0x20, 0x00, 0xa0, 0x02, 0x00
+};
+
+static const uint8_t ds4_feature_mac[] = { // report 0x12 (device/host MAC + BT class)
+  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // device MAC address
+  0x08, 0x25, 0x00,                   // BT device class
+  0x00, 0x00, 0x00, 0x00, 0x00, 0x00  // host MAC address
+};
+
+// Joybus read origin callback
+static void joybus_read_origin_cb(struct joybus *bus, int result, void *user_data)
+{
+  // Return to identify mode on any error
+  if (result < 0)
+    poll_mode = POLL_MODE_IDENTIFY;
+}
+
+// Joybus identify callback
+static void joybus_identify_cb(struct joybus *bus, int result, void *user_data)
+{
+  // Stay in identify mode on any Joybus error
+  if (result < 0)
+    return;
+
+  // Check it's a GameCube controller
+  uint16_t type = id.type;
+  if (!(type & JOYBUS_TYPE_GCN_DEVICE))
+    return;
+
+  // Check we've received data if it's a wireless controller
+  if ((type & JOYBUS_TYPE_GCN_WIRELESS) && !(type & JOYBUS_TYPE_GCN_WIRELESS_RECEIVED))
+    return;
+
+  // Check it's a standard controller
+  if (!(type & JOYBUS_TYPE_GCN_STANDARD))
+    return;
+
+  // Read the origin
+  joybus_gcn_read_origin_async(bus, &origin, joybus_read_origin_cb, NULL);
+
+  // Move to polling for input
+  poll_mode = POLL_MODE_READ;
+}
+
+// Joybus GCN read callback
+static void joybus_read_cb(struct joybus *bus, int result, void *user_data)
+{
+  // Return to identify mode on any error
+  if (result < 0) {
+    poll_mode = POLL_MODE_IDENTIFY;
+    return;
+  }
+
+  // If the "need origin" flag is set, fetch the origin state again
+  if (input.buttons & JOYBUS_GCN_NEED_ORIGIN)
+    joybus_gcn_read_origin_async(bus, &origin, joybus_read_origin_cb, NULL);
+}
+
+// Clamp an axis value based on the origin and expected resting position
+static inline uint8_t clamp_axis(uint8_t value, uint8_t origin, uint8_t resting)
+{
+  int adjusted = value + (resting - origin);
+  if (adjusted < 0)
+    adjusted = 0;
+  else if (adjusted > 255)
+    adjusted = 255;
+
+  return adjusted;
+}
+
+// Map the GameCube D-pad to a DualShock 4 hat value
+static uint8_t get_ds4_hat(const struct joybus_gcn_controller_state *input)
+{
+  bool up    = input->buttons & JOYBUS_GCN_BUTTON_UP;
+  bool down  = input->buttons & JOYBUS_GCN_BUTTON_DOWN;
+  bool left  = input->buttons & JOYBUS_GCN_BUTTON_LEFT;
+  bool right = input->buttons & JOYBUS_GCN_BUTTON_RIGHT;
+
+  if (up && right)
+    return DS4_HAT_UP_RIGHT;
+  if (right && down)
+    return DS4_HAT_DOWN_RIGHT;
+  if (down && left)
+    return DS4_HAT_DOWN_LEFT;
+  if (left && up)
+    return DS4_HAT_UP_LEFT;
+  if (up)
+    return DS4_HAT_UP;
+  if (right)
+    return DS4_HAT_RIGHT;
+  if (down)
+    return DS4_HAT_DOWN;
+  if (left)
+    return DS4_HAT_LEFT;
+
+  return DS4_HAT_NEUTRAL;
+}
+
+// Build a DualShock 4 input report (report 0x01) from the GameCube controller
+// state. The GameCube layout is mapped onto the DS4 as:
+//   A->Cross, B->Circle, X->Square, Y->Triangle, Start->Options, Z->R1,
+//   L->L2 (analog + click), R->R2 (analog + click). L1/L3/R3/Share/PS/Touchpad
+//   have no GameCube equivalent and are left unpressed.
+static void build_ds4_report(void)
+{
+  uint16_t buttons = input.buttons;
+
+  memset(report_buf, 0, sizeof(report_buf));
+  report_buf[0] = DS4_INPUT_REPORT_ID;
+
+  // Analog sticks (DS4 axes are unsigned, centered at 0x80). The GameCube
+  // reports "up" as an increasing value, whereas the DS4 expects "up" to be
+  // 0x00, so the Y axes are inverted.
+  report_buf[1] = clamp_axis(input.stick_x, origin.stick_x, 0x80);
+  report_buf[2] = 0xFF - clamp_axis(input.stick_y, origin.stick_y, 0x80);
+  report_buf[3] = clamp_axis(input.substick_x, origin.substick_x, 0x80);
+  report_buf[4] = 0xFF - clamp_axis(input.substick_y, origin.substick_y, 0x80);
+
+  // D-pad (low nibble) plus the four face buttons (high nibble)
+  report_buf[5] = get_ds4_hat(&input);
+  if (buttons & JOYBUS_GCN_BUTTON_X)
+    report_buf[5] |= 1 << 4; // Square
+  if (buttons & JOYBUS_GCN_BUTTON_A)
+    report_buf[5] |= 1 << 5; // Cross
+  if (buttons & JOYBUS_GCN_BUTTON_B)
+    report_buf[5] |= 1 << 6; // Circle
+  if (buttons & JOYBUS_GCN_BUTTON_Y)
+    report_buf[5] |= 1 << 7; // Triangle
+
+  // Shoulder/trigger clicks and menu buttons
+  if (buttons & JOYBUS_GCN_BUTTON_L)
+    report_buf[6] |= 1 << 2; // L2 (click)
+  if (buttons & JOYBUS_GCN_BUTTON_R)
+    report_buf[6] |= 1 << 3; // R2 (click)
+  if (buttons & JOYBUS_GCN_BUTTON_Z)
+    report_buf[6] |= 1 << 1; // R1
+  if (buttons & JOYBUS_GCN_BUTTON_START)
+    report_buf[6] |= 1 << 5; // Options
+
+  // 6-bit report counter (bits 2-7 of byte 7)
+  report_buf[7] = (report_counter++ & 0x3F) << 2;
+
+  // Analog triggers
+  report_buf[8] = clamp_axis(input.trigger_left, origin.trigger_left, 0x00);
+  report_buf[9] = clamp_axis(input.trigger_right, origin.trigger_right, 0x00);
+}
+
+// Send DS4 input reports at a regular interval
+static bool poll_task(struct repeating_timer *timer)
+{
+  // Poll Joybus for data
+  switch (poll_mode) {
+    case POLL_MODE_IDENTIFY:
+      joybus_identify_async(bus, &id, joybus_identify_cb, NULL);
+      break;
+
+    case POLL_MODE_READ:
+      joybus_gcn_read_async(bus, JOYBUS_GCN_ANALOG_MODE_3, motor_state, &input, joybus_read_cb, NULL);
+      break;
+  }
+
+  // Send a DS4 input report. The report ID is already in report_buf[0], so pass
+  // report_id 0 to send the buffer verbatim.
+  if (tud_hid_ready()) {
+    build_ds4_report();
+    tud_hid_report(0, report_buf, sizeof(report_buf));
+  }
+
+  return true;
+}
+
+// Invoked when received GET_REPORT control request
+// Application must fill buffer report's content and return its length.
+// Return zero will cause the stack to STALL request
+uint16_t tud_hid_get_report_cb(uint8_t instance, uint8_t report_id, hid_report_type_t report_type, uint8_t *buffer,
+                               uint16_t reqlen)
+{
+  if (report_type != HID_REPORT_TYPE_FEATURE)
+    return 0;
+
+  const uint8_t *src = NULL;
+  uint16_t len       = 0;
+
+  switch (report_id) {
+    case 0x02:
+      src = ds4_feature_calibration;
+      len = sizeof(ds4_feature_calibration);
+      break;
+    case 0x03:
+      src = ds4_feature_definition;
+      len = sizeof(ds4_feature_definition);
+      break;
+    case 0xA3:
+      src = ds4_feature_version;
+      len = sizeof(ds4_feature_version);
+      break;
+    case 0x12:
+      src = ds4_feature_mac;
+      len = sizeof(ds4_feature_mac);
+      break;
+    default:
+      return 0;
+  }
+
+  if (len > reqlen)
+    len = reqlen;
+
+  memcpy(buffer, src, len);
+  return len;
+}
+
+// Invoked when received SET_REPORT control request or
+// received data on OUT endpoint ( Report ID = 0, Type = 0 )
+void tud_hid_set_report_cb(uint8_t instance, uint8_t report_id, hid_report_type_t report_type, const uint8_t *buffer,
+                           uint16_t bufsize)
+{
+  // Feature writes (e.g. the PS4 auth handshake) are not needed on macOS
+  if (report_type == HID_REPORT_TYPE_FEATURE)
+    return;
+
+  uint8_t id          = report_id;
+  const uint8_t *data = buffer;
+  uint16_t len        = bufsize;
+
+  // On the interrupt OUT endpoint TinyUSB delivers the whole report with the
+  // report ID as the first byte and report_id == 0. Over the control endpoint
+  // (SET_REPORT) the ID is stripped out and passed in report_id.
+  if (id == 0 && len > 0) {
+    id = data[0];
+    data++;
+    len--;
+  }
+
+  // The DS4 rumble/LED output report carries two motor magnitudes:
+  //   data[3] = right (weak) motor, data[4] = left (strong) motor.
+  // The GameCube motor is on/off only, so any non-zero magnitude turns it on.
+  if (id == DS4_OUTPUT_REPORT_ID && len >= 5) {
+    uint8_t weak   = data[3];
+    uint8_t strong = data[4];
+    motor_state    = (weak || strong) ? JOYBUS_GCN_MOTOR_RUMBLE : JOYBUS_GCN_MOTOR_STOP;
+  }
+}
+
+int main(void)
+{
+  // Initialize TinyUSB
+  tusb_init();
+
+  // Initialize Joybus
+  joybus_rp2xxx_init(&rp2xxx_bus, joybus_rp2xxx_config_default(JOYBUS_GPIO));
+  joybus_enable(bus, JOYBUS_MODE_HOST);
+
+  // Poll for Joybus data and send HID reports at regular intervals
+  struct repeating_timer poll_timer;
+  add_repeating_timer_ms(POLL_INTERVAL, poll_task, NULL, &poll_timer);
+
+  // Handle USB events
+  while (true)
+    tud_task();
+
+  return 0;
+}

--- a/examples/pico-sdk/gcn-adapter-ds4/tusb_config.h
+++ b/examples/pico-sdk/gcn-adapter-ds4/tusb_config.h
@@ -1,0 +1,18 @@
+#pragma once
+
+//--------------------------------------------------------------------
+// COMMON CONFIGURATION
+//--------------------------------------------------------------------
+
+#define CFG_TUSB_MCU            OPT_MCU_RP2040
+#define CFG_TUSB_RHPORT0_MODE   OPT_MODE_DEVICE
+#define CFG_TUD_ENDPOINT0_SIZE  64
+
+//--------------------------------------------------------------------
+// DEVICE CONFIGURATION
+//--------------------------------------------------------------------
+
+#define CFG_TUD_HID             1
+
+// HID buffer size (must match w/ endpoint size in descriptor)
+#define CFG_TUD_HID_EP_BUFSIZE  64

--- a/examples/pico-sdk/gcn-adapter-ds4/usb_descriptors.c
+++ b/examples/pico-sdk/gcn-adapter-ds4/usb_descriptors.c
@@ -1,0 +1,354 @@
+#include <string.h>
+
+#include "tusb.h"
+
+// Present as a Sony DualShock 4 (v1). macOS recognizes this VID/PID and drives
+// the controller natively through its GameController framework, including rumble
+// via output report 0x05. See main.c for how the DS4 reports are built/decoded.
+#define VENDOR_ID   0x054C
+#define PRODUCT_ID  0x05C4
+
+// Interrupt endpoints. The DS4 uses both an IN endpoint (input + GET_REPORT
+// responses) and an OUT endpoint (rumble/LED output reports).
+#define EP_OUT      0x03
+#define EP_IN       0x84
+
+// Device Descriptor
+static const tusb_desc_device_t device_desc = {
+  .bLength            = sizeof(tusb_desc_device_t),
+  .bDescriptorType    = TUSB_DESC_DEVICE,
+  .bcdUSB             = 0x0200,
+  .bDeviceClass       = 0x00,
+  .bDeviceSubClass    = 0x00,
+  .bDeviceProtocol    = 0x00,
+  .bMaxPacketSize0    = CFG_TUD_ENDPOINT0_SIZE,
+  .idVendor           = VENDOR_ID,
+  .idProduct          = PRODUCT_ID,
+  .bcdDevice          = 0x0100,
+  .iManufacturer      = 0x01,
+  .iProduct           = 0x02,
+  .iSerialNumber      = 0,
+  .bNumConfigurations = 0x01,
+};
+
+// Invoked when received GET DEVICE DESCRIPTOR
+// Application return pointer to descriptor
+uint8_t const *tud_descriptor_device_cb(void)
+{
+  return (uint8_t const *)&device_desc;
+}
+
+// HID Report Descriptor
+//
+// This is the DualShock 4 (USB) report descriptor, reproduced verbatim so that
+// macOS binds its native DS4 support: input report 0x01 (controller state),
+// output report 0x05 (rumble/LED), and the DS4 feature reports. The trailing
+// 0xF0-0xF3 vendor collection is the PS4 console authentication interface; it is
+// harmless on macOS (which never exercises it) and is kept for fidelity.
+static const uint8_t hid_report_desc[] = {
+  0x05, 0x01,        // Usage Page (Generic Desktop Ctrls)
+  0x09, 0x05,        // Usage (Game Pad)
+  0xA1, 0x01,        // Collection (Application)
+  0x85, 0x01,        //   Report ID (1)
+  0x09, 0x30,        //   Usage (X)
+  0x09, 0x31,        //   Usage (Y)
+  0x09, 0x32,        //   Usage (Z)
+  0x09, 0x35,        //   Usage (Rz)
+  0x15, 0x00,        //   Logical Minimum (0)
+  0x26, 0xFF, 0x00,  //   Logical Maximum (255)
+  0x75, 0x08,        //   Report Size (8)
+  0x95, 0x04,        //   Report Count (4)
+  0x81, 0x02,        //   Input (Data,Var,Abs)
+  0x09, 0x39,        //   Usage (Hat switch)
+  0x15, 0x00,        //   Logical Minimum (0)
+  0x25, 0x07,        //   Logical Maximum (7)
+  0x35, 0x00,        //   Physical Minimum (0)
+  0x46, 0x3B, 0x01,  //   Physical Maximum (315)
+  0x65, 0x14,        //   Unit (Eng Rot: Degrees)
+  0x75, 0x04,        //   Report Size (4)
+  0x95, 0x01,        //   Report Count (1)
+  0x81, 0x42,        //   Input (Data,Var,Abs,Null State)
+  0x65, 0x00,        //   Unit (None)
+  0x05, 0x09,        //   Usage Page (Button)
+  0x19, 0x01,        //   Usage Minimum (0x01)
+  0x29, 0x0E,        //   Usage Maximum (0x0E)
+  0x15, 0x00,        //   Logical Minimum (0)
+  0x25, 0x01,        //   Logical Maximum (1)
+  0x75, 0x01,        //   Report Size (1)
+  0x95, 0x0E,        //   Report Count (14)
+  0x81, 0x02,        //   Input (Data,Var,Abs)
+  0x06, 0x00, 0xFF,  //   Usage Page (Vendor Defined 0xFF00)
+  0x09, 0x20,        //   Usage (0x20)
+  0x75, 0x06,        //   Report Size (6)
+  0x95, 0x01,        //   Report Count (1)
+  0x81, 0x02,        //   Input (Data,Var,Abs)
+  0x05, 0x01,        //   Usage Page (Generic Desktop Ctrls)
+  0x09, 0x33,        //   Usage (Rx)
+  0x09, 0x34,        //   Usage (Ry)
+  0x15, 0x00,        //   Logical Minimum (0)
+  0x26, 0xFF, 0x00,  //   Logical Maximum (255)
+  0x75, 0x08,        //   Report Size (8)
+  0x95, 0x02,        //   Report Count (2)
+  0x81, 0x02,        //   Input (Data,Var,Abs)
+  0x06, 0x00, 0xFF,  //   Usage Page (Vendor Defined 0xFF00)
+  0x09, 0x21,        //   Usage (0x21)
+  0x95, 0x36,        //   Report Count (54)
+  0x81, 0x02,        //   Input (Data,Var,Abs)
+  0x85, 0x05,        //   Report ID (5)
+  0x09, 0x22,        //   Usage (0x22)
+  0x95, 0x1F,        //   Report Count (31)
+  0x91, 0x02,        //   Output (Data,Var,Abs)
+  0x85, 0x03,        //   Report ID (3)
+  0x0A, 0x21, 0x27,  //   Usage (0x2721)
+  0x95, 0x2F,        //   Report Count (47)
+  0xB1, 0x02,        //   Feature (Data,Var,Abs)
+  0x85, 0x02,        //   Report ID (2)
+  0x09, 0x24,        //   Usage (0x24)
+  0x95, 0x24,        //   Report Count (36)
+  0xB1, 0x02,        //   Feature (Data,Var,Abs)
+  0x85, 0x08,        //   Report ID (8)
+  0x09, 0x25,        //   Usage (0x25)
+  0x95, 0x03,        //   Report Count (3)
+  0xB1, 0x02,        //   Feature (Data,Var,Abs)
+  0x85, 0x10,        //   Report ID (16)
+  0x09, 0x26,        //   Usage (0x26)
+  0x95, 0x04,        //   Report Count (4)
+  0xB1, 0x02,        //   Feature (Data,Var,Abs)
+  0x85, 0x11,        //   Report ID (17)
+  0x09, 0x27,        //   Usage (0x27)
+  0x95, 0x02,        //   Report Count (2)
+  0xB1, 0x02,        //   Feature (Data,Var,Abs)
+  0x85, 0x12,        //   Report ID (18)
+  0x06, 0x02, 0xFF,  //   Usage Page (Vendor Defined 0xFF02)
+  0x09, 0x21,        //   Usage (0x21)
+  0x95, 0x0F,        //   Report Count (15)
+  0xB1, 0x02,        //   Feature (Data,Var,Abs)
+  0x85, 0x13,        //   Report ID (19)
+  0x09, 0x22,        //   Usage (0x22)
+  0x95, 0x16,        //   Report Count (22)
+  0xB1, 0x02,        //   Feature (Data,Var,Abs)
+  0x85, 0x14,        //   Report ID (20)
+  0x06, 0x05, 0xFF,  //   Usage Page (Vendor Defined 0xFF05)
+  0x09, 0x20,        //   Usage (0x20)
+  0x95, 0x10,        //   Report Count (16)
+  0xB1, 0x02,        //   Feature (Data,Var,Abs)
+  0x85, 0x15,        //   Report ID (21)
+  0x09, 0x21,        //   Usage (0x21)
+  0x95, 0x2C,        //   Report Count (44)
+  0xB1, 0x02,        //   Feature (Data,Var,Abs)
+  0x06, 0x80, 0xFF,  //   Usage Page (Vendor Defined 0xFF80)
+  0x85, 0x80,        //   Report ID (128)
+  0x09, 0x20,        //   Usage (0x20)
+  0x95, 0x06,        //   Report Count (6)
+  0xB1, 0x02,        //   Feature (Data,Var,Abs)
+  0x85, 0x81,        //   Report ID (129)
+  0x09, 0x21,        //   Usage (0x21)
+  0x95, 0x06,        //   Report Count (6)
+  0xB1, 0x02,        //   Feature (Data,Var,Abs)
+  0x85, 0x82,        //   Report ID (130)
+  0x09, 0x22,        //   Usage (0x22)
+  0x95, 0x05,        //   Report Count (5)
+  0xB1, 0x02,        //   Feature (Data,Var,Abs)
+  0x85, 0x83,        //   Report ID (131)
+  0x09, 0x23,        //   Usage (0x23)
+  0x95, 0x01,        //   Report Count (1)
+  0xB1, 0x02,        //   Feature (Data,Var,Abs)
+  0x85, 0x84,        //   Report ID (132)
+  0x09, 0x24,        //   Usage (0x24)
+  0x95, 0x04,        //   Report Count (4)
+  0xB1, 0x02,        //   Feature (Data,Var,Abs)
+  0x85, 0x85,        //   Report ID (133)
+  0x09, 0x25,        //   Usage (0x25)
+  0x95, 0x06,        //   Report Count (6)
+  0xB1, 0x02,        //   Feature (Data,Var,Abs)
+  0x85, 0x86,        //   Report ID (134)
+  0x09, 0x26,        //   Usage (0x26)
+  0x95, 0x06,        //   Report Count (6)
+  0xB1, 0x02,        //   Feature (Data,Var,Abs)
+  0x85, 0x87,        //   Report ID (135)
+  0x09, 0x27,        //   Usage (0x27)
+  0x95, 0x23,        //   Report Count (35)
+  0xB1, 0x02,        //   Feature (Data,Var,Abs)
+  0x85, 0x88,        //   Report ID (136)
+  0x09, 0x28,        //   Usage (0x28)
+  0x95, 0x22,        //   Report Count (34)
+  0xB1, 0x02,        //   Feature (Data,Var,Abs)
+  0x85, 0x89,        //   Report ID (137)
+  0x09, 0x29,        //   Usage (0x29)
+  0x95, 0x02,        //   Report Count (2)
+  0xB1, 0x02,        //   Feature (Data,Var,Abs)
+  0x85, 0x90,        //   Report ID (144)
+  0x09, 0x30,        //   Usage (0x30)
+  0x95, 0x05,        //   Report Count (5)
+  0xB1, 0x02,        //   Feature (Data,Var,Abs)
+  0x85, 0x91,        //   Report ID (145)
+  0x09, 0x31,        //   Usage (0x31)
+  0x95, 0x03,        //   Report Count (3)
+  0xB1, 0x02,        //   Feature (Data,Var,Abs)
+  0x85, 0x92,        //   Report ID (146)
+  0x09, 0x32,        //   Usage (0x32)
+  0x95, 0x03,        //   Report Count (3)
+  0xB1, 0x02,        //   Feature (Data,Var,Abs)
+  0x85, 0x93,        //   Report ID (147)
+  0x09, 0x33,        //   Usage (0x33)
+  0x95, 0x0C,        //   Report Count (12)
+  0xB1, 0x02,        //   Feature (Data,Var,Abs)
+  0x85, 0xA0,        //   Report ID (160)
+  0x09, 0x40,        //   Usage (0x40)
+  0x95, 0x06,        //   Report Count (6)
+  0xB1, 0x02,        //   Feature (Data,Var,Abs)
+  0x85, 0xA1,        //   Report ID (161)
+  0x09, 0x41,        //   Usage (0x41)
+  0x95, 0x01,        //   Report Count (1)
+  0xB1, 0x02,        //   Feature (Data,Var,Abs)
+  0x85, 0xA2,        //   Report ID (162)
+  0x09, 0x42,        //   Usage (0x42)
+  0x95, 0x01,        //   Report Count (1)
+  0xB1, 0x02,        //   Feature (Data,Var,Abs)
+  0x85, 0xA3,        //   Report ID (163)
+  0x09, 0x43,        //   Usage (0x43)
+  0x95, 0x30,        //   Report Count (48)
+  0xB1, 0x02,        //   Feature (Data,Var,Abs)
+  0x85, 0xA4,        //   Report ID (164)
+  0x09, 0x44,        //   Usage (0x44)
+  0x95, 0x0D,        //   Report Count (13)
+  0xB1, 0x02,        //   Feature (Data,Var,Abs)
+  0x85, 0xA5,        //   Report ID (165)
+  0x09, 0x45,        //   Usage (0x45)
+  0x95, 0x15,        //   Report Count (21)
+  0xB1, 0x02,        //   Feature (Data,Var,Abs)
+  0x85, 0xA6,        //   Report ID (166)
+  0x09, 0x46,        //   Usage (0x46)
+  0x95, 0x15,        //   Report Count (21)
+  0xB1, 0x02,        //   Feature (Data,Var,Abs)
+  0x85, 0xA7,        //   Report ID (247)
+  0x09, 0x4A,        //   Usage (0x4A)
+  0x95, 0x01,        //   Report Count (1)
+  0xB1, 0x02,        //   Feature (Data,Var,Abs)
+  0x85, 0xA8,        //   Report ID (250)
+  0x09, 0x4B,        //   Usage (0x4B)
+  0x95, 0x01,        //   Report Count (1)
+  0xB1, 0x02,        //   Feature (Data,Var,Abs)
+  0x85, 0xA9,        //   Report ID (251)
+  0x09, 0x4C,        //   Usage (0x4C)
+  0x95, 0x08,        //   Report Count (8)
+  0xB1, 0x02,        //   Feature (Data,Var,Abs)
+  0x85, 0xAA,        //   Report ID (252)
+  0x09, 0x4E,        //   Usage (0x4E)
+  0x95, 0x01,        //   Report Count (1)
+  0xB1, 0x02,        //   Feature (Data,Var,Abs)
+  0x85, 0xAB,        //   Report ID (253)
+  0x09, 0x4F,        //   Usage (0x4F)
+  0x95, 0x39,        //   Report Count (57)
+  0xB1, 0x02,        //   Feature (Data,Var,Abs)
+  0x85, 0xAC,        //   Report ID (254)
+  0x09, 0x50,        //   Usage (0x50)
+  0x95, 0x39,        //   Report Count (57)
+  0xB1, 0x02,        //   Feature (Data,Var,Abs)
+  0x85, 0xAD,        //   Report ID (255)
+  0x09, 0x51,        //   Usage (0x51)
+  0x95, 0x0B,        //   Report Count (11)
+  0xB1, 0x02,        //   Feature (Data,Var,Abs)
+  0x85, 0xAE,        //   Report ID (174)
+  0x09, 0x52,        //   Usage (0x52)
+  0x95, 0x01,        //   Report Count (1)
+  0xB1, 0x02,        //   Feature (Data,Var,Abs)
+  0x85, 0xAF,        //   Report ID (175)
+  0x09, 0x53,        //   Usage (0x53)
+  0x95, 0x02,        //   Report Count (2)
+  0xB1, 0x02,        //   Feature (Data,Var,Abs)
+  0x85, 0xB0,        //   Report ID (176)
+  0x09, 0x54,        //   Usage (0x54)
+  0x95, 0x3F,        //   Report Count (63)
+  0xB1, 0x02,        //   Feature (Data,Var,Abs)
+  0xC0,              // End Collection
+  0x06, 0xF0, 0xFF,  // Usage Page (Vendor Defined 0xFFF0)
+  0x09, 0x40,        // Usage (0x40)
+  0xA1, 0x01,        // Collection (Application)
+  0x85, 0xF0,        //   Report ID (240) - PS4 auth challenge
+  0x09, 0x47,        //   Usage (0x47)
+  0x95, 0x3F,        //   Report Count (63)
+  0xB1, 0x02,        //   Feature (Data,Var,Abs)
+  0x85, 0xF1,        //   Report ID (241) - PS4 auth response
+  0x09, 0x48,        //   Usage (0x48)
+  0x95, 0x3F,        //   Report Count (63)
+  0xB1, 0x02,        //   Feature (Data,Var,Abs)
+  0x85, 0xF2,        //   Report ID (242) - PS4 auth status
+  0x09, 0x49,        //   Usage (0x49)
+  0x95, 0x0F,        //   Report Count (15)
+  0xB1, 0x02,        //   Feature (Data,Var,Abs)
+  0x85, 0xF3,        //   Report ID (243) - PS4 auth reset
+  0x0A, 0x01, 0x47,  //   Usage (0x4701)
+  0x95, 0x07,        //   Report Count (7)
+  0xB1, 0x02,        //   Feature (Data,Var,Abs)
+  0xC0,              // End Collection
+};
+
+// Invoked when received GET HID REPORT DESCRIPTOR
+// Application return pointer to descriptor
+// Descriptor contents must exist long enough for transfer to complete
+uint8_t const *tud_hid_descriptor_report_cb(uint8_t itf)
+{
+  return hid_report_desc;
+}
+
+// Configuration Descriptor
+// The DS4 interface has both an interrupt IN and an interrupt OUT endpoint, so
+// use the HID in/out descriptor rather than the input-only variant.
+static const uint8_t configuration_desc[] = {
+  TUD_CONFIG_DESCRIPTOR(1, 1, 0, (TUD_CONFIG_DESC_LEN + TUD_HID_INOUT_DESC_LEN), 0x00, 500),
+  TUD_HID_INOUT_DESCRIPTOR(0, 0, HID_ITF_PROTOCOL_NONE, sizeof(hid_report_desc), EP_OUT, EP_IN,
+                           CFG_TUD_HID_EP_BUFSIZE, 1),
+};
+
+// Invoked when received GET CONFIGURATION DESCRIPTOR
+// Application return pointer to descriptor
+// Descriptor contents must exist long enough for transfer to complete
+uint8_t const *tud_descriptor_configuration_cb(uint8_t index)
+{
+  return configuration_desc;
+}
+
+// String Descriptors
+static const char *string_desc[] = {
+  (const char[]){0x09, 0x04},      // 0: is supported language is English (0x0409)
+  "Sony Computer Entertainment",   // 1: Manufacturer
+  "Wireless Controller",           // 2: Product
+};
+
+// Invoked when received GET STRING DESCRIPTOR request
+// Application return pointer to descriptor, whose contents must exist long enough for transfer to complete
+const uint16_t *tud_descriptor_string_cb(uint8_t index, uint16_t langid)
+{
+  static uint16_t desc_str[32 + 1];
+  size_t chr_count;
+
+  switch (index) {
+    case 0x00:
+      memcpy(&desc_str[1], string_desc[0], 2);
+      chr_count = 1;
+      break;
+
+    default:
+      if (!(index < sizeof(string_desc) / sizeof(string_desc[0])))
+        return NULL;
+
+      const char *str = string_desc[index];
+
+      // Cap at max char
+      chr_count              = strlen(str);
+      size_t const max_count = sizeof(desc_str) / sizeof(desc_str[0]) - 1; // -1 for string type
+      if (chr_count > max_count)
+        chr_count = max_count;
+
+      // Convert ASCII string into UTF-16
+      for (size_t i = 0; i < chr_count; i++)
+        desc_str[1 + i] = str[i];
+      break;
+  }
+
+  // first byte is length (including header), second byte is string type
+  desc_str[0] = (uint16_t)((TUSB_DESC_STRING << 8) | (2 * chr_count + 2));
+
+  return desc_str;
+}

--- a/libjoybus.code-workspace
+++ b/libjoybus.code-workspace
@@ -24,6 +24,10 @@
       "path": "examples/pico-sdk/gcn-adapter-nintendo"
     },
     {
+      "name": "Pico SDK/GCN Adapter (DS4)",
+      "path": "examples/pico-sdk/gcn-adapter-ds4"
+    },
+    {
       "name": "Pico SDK/GCN Adapter (USB HID)",
       "path": "examples/pico-sdk/gcn-adapter-usb-hid"
     },


### PR DESCRIPTION
Disclosure: Claude Code was used to make this example. I (catskull) am manually writing this pull request.

Thanks so much for this awesome library and examples!

I wanted rumble support on macOS. As far as I can tell no other adapter currently has this ability. Claude modified the `gcn-adapter-usb-hid` example to emulate a DualShock 4 so macOS would natively support it and also rumble. Tested on my MacBook running Tahoe 26.5.1.

Attached is the uf2. Because I was using a RP2040-zero board, I changed the GPIO from 12 to 29 just for ease of wiring. However the code is still using 12 for consistency.

[gcn-adapter-ds4.uf2.zip](https://github.com/user-attachments/files/29821555/gcn-adapter-ds4.uf2.zip)